### PR TITLE
Feature/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.2"
 virtualenv:
   system_site_packages: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+virtualenv:
+  system_site_packages: true
+install:
+  - travis_retry python setup.py develop
+script: "nosetests -w tests/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.2"
-virtualenv:
-  system_site_packages: true
 install:
   - travis_retry python setup.py develop
 script: "nosetests -w tests/"


### PR DESCRIPTION
add automated continuous integration testing through travis

- it currently works, see https://travis-ci.org/hroest/autowrap/builds
- you will have to set this up to also work with your repo by connecting your account to travis
- once you enable it, this is how it will show up like this in the pull requests
https://github.com/hroest/autowrap/pull/1

this is for Python 2 and 3, so there wont be any issues any more regarding people that do not test their commits against both versions
