### PR TITLE
[TEST] test 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.4"
+  - "3.5"
 install:
   - travis_retry python setup.py develop
 script: "nosetests -w tests/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.6"
   - "2.7"
   - "3.2"
+  - "3.4"
 install:
   - travis_retry python setup.py develop
 script: "nosetests -w tests/"


### PR DESCRIPTION
We should also test for Python 3.4 compatbility as this is the default python3 version in Ubuntu trusty (LTS 14.04) as well as debian stable, testing and unstable (jessie, stretch, sid). At some point next year, Ubuntu xenial (LTS 16.04) will be released with 3.5 at which point all should work for that as well.

Currently 3.4 works: https://travis-ci.org/hroest/autowrap/builds/94021295
