### PR TITLE
Feature/static header

### DIFF
--- a/autowrap/Main.py
+++ b/autowrap/Main.py
@@ -130,7 +130,7 @@ def collect_manual_code(addons):
         clz_name, __ = os.path.splitext(os.path.basename(name))
         line_iter = open(name, "r")
         for line in line_iter:
-            if line and line[0] not in "\n\r\t ":
+            if line and line.strip() not in "\n\r\t ":
                 cimports.append(line)
             else:
                 break

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 7, 1)
+__version__ = (0, 7, 2)
 
 # for compatibility to older version:
 version = __version__

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -509,6 +509,10 @@ def test_stl_libcpp():
     assert list(res.values())[0].i_ == 5
     assert list(res.keys())[0] == 5 + 10
 
+    # Test shared_ptr < const Widget >
+    const_res = t.process_11_const()
+    const_res.i_ == 42
+
 def test_minimal():
 
     from autowrap.ConversionProvider import (TypeConverterBase,

--- a/tests/test_files/libcpp_stl_test.hpp
+++ b/tests/test_files/libcpp_stl_test.hpp
@@ -122,4 +122,10 @@ class LibCppSTLTest {
             res[in_ + 10] = wr;
             return res;
         }
+
+        boost::shared_ptr<const IntWrapper> process_11_const()
+        {
+            boost::shared_ptr<IntWrapper> ptr(new IntWrapper(42));
+            return boost::static_pointer_cast<const IntWrapper>(ptr);
+        }
 };

--- a/tests/test_files/libcpp_stl_test.pxd
+++ b/tests/test_files/libcpp_stl_test.pxd
@@ -30,3 +30,5 @@ cdef extern from "libcpp_stl_test.hpp":
         int process_9_map(libcpp_map[int, IntWrapper] & in_)
         libcpp_map[int, IntWrapper] process_10_map(int in_)
 
+        shared_ptr[const IntWrapper] process_11_const()
+


### PR DESCRIPTION
- this will allow multiple lines to be added to the Cython header, even full functions
- this is necessary for user-defined static functions