### PR TITLE
Feature/empty constructor

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -703,7 +703,7 @@ class CodeGenerator(object):
 
     def create_wrapper_for_nonoverloaded_constructor(self, class_decl, py_name,
                                                      cons_decl):
-        """ py_name ist name for constructor, as we dispatch overloaded
+        """ py_name is the name for constructor, as we dispatch overloaded
             constructors in __init__() the name of the method calling the
             c++ constructor is variable and given by `py_name`.
 
@@ -713,6 +713,11 @@ class CodeGenerator(object):
 
         call_args, cleanups, in_types =\
             self._create_fun_decl_and_input_conversion(cons_code, py_name, cons_decl)
+
+        wrap_pass = cons_decl.cpp_decl.annotations.get("wrap-pass-constructor", False)
+        if wrap_pass:
+            cons_code.add( "    pass")
+            return cons_code
 
         # create instance of wrapped class
         call_args_str = ", ".join(call_args)

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 7, 3)
+__version__ = (0, 7, 4)
 
 # for compatibility to older version:
 version = __version__

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -424,6 +424,9 @@ def test_libcpp():
     res = t.process40(i2)
     assert res == 4
 
+    assert i1.get() == 1
+    assert i2.get() == 4
+
     # Use in dict/set
     # For this to work, the class needs to have __hash__ and __richcmp__ which
     # are wrapped by "wrap-hash" and operator== and operator!=

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -418,7 +418,7 @@ def test_libcpp():
 
     # Testing abstract base class
     i1 = libcpp.ABS_Impl1(1)
-    i2 = libcpp.ABS_Impl2(4)
+    i2 = libcpp.ABS_Impl1(4)
     res = t.process40(i1)
     assert res == 1
     res = t.process40(i2)
@@ -426,6 +426,22 @@ def test_libcpp():
 
     assert i1.get() == 1
     assert i2.get() == 4
+
+    # Testing unsafe call
+    i1 = libcpp.ABS_Impl1(__createUnsafeObject__=True)
+    i2 = libcpp.ABS_Impl2(__createUnsafeObject__=True)
+
+    try:
+        i1 = libcpp.ABS_Impl1()
+        raise Exception("Expected Exception not thrown")
+    except Exception:
+        pass
+
+    try:
+        i1 = libcpp.ABS_Impl2()
+        raise Exception("Expected Exception not thrown")
+    except Exception:
+        pass
 
     # Use in dict/set
     # For this to work, the class needs to have __hash__ and __richcmp__ which

--- a/tests/test_files/libcpp_test.pxd
+++ b/tests/test_files/libcpp_test.pxd
@@ -30,13 +30,15 @@ cdef extern from "libcpp_test.hpp":
         # wrap-inherits:
         #  AbstractBaseClass
         # ABS_Impl1(ABS_Impl1)
+        ABS_Impl1() # wrap-pass-constructor
         ABS_Impl1(int i)
 
     cdef cppclass ABS_Impl2(AbstractBaseClass):
         # wrap-inherits:
         #  AbstractBaseClass
         # ABS_Impl2(ABS_Impl2)
-        ABS_Impl2(int i)
+        ABS_Impl2() # wrap-pass-constructor
+        ABS_Impl2(int i) # wrap-ignore
 
 
     cdef cppclass LibCppTest:

--- a/tests/test_files/libcpp_test.pxd
+++ b/tests/test_files/libcpp_test.pxd
@@ -23,6 +23,7 @@ cdef extern from "libcpp_test.hpp":
         # wrap-ignore
         # ABSTRACT class
         int i_
+        int get()
         # AbstractBaseClass(AbstractBaseClass) # wrap-ignore
 
     cdef cppclass ABS_Impl1(AbstractBaseClass):


### PR DESCRIPTION
note that this is somewhat dangerous but it allows us to write

```
    cdef cppclass myClass(ABClass):
        # wrap-inherits:
        #  ABClass
        myClass() nogil except + # wrap-pass-constructor
```

even if `myClass()` is private. This is necessary if we want to handle abstract base classes as shown above (as `ABClass`) and we need to construct new objects of type myClass, for example in this case

```
cdef _myClass * class_ptr = dynamic_cast[ _myClassPtr ](shared_abclass_ptr.get() )
if (class_ptr != NULL):
  result = myClass()
  result.inst = dynamic_pointer_cast[_myClass, _ABClass](shared_abclass_ptr)
  return result
```
this does not seem very kosher but it seems the only way to do it -- any other ideas, @uweschmitt ?
