### PR TITLE
[FEATURE] ptr and const ptr holder

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -958,6 +958,8 @@ class CodeGenerator(object):
                    |from  libcpp.map     cimport map  as libcpp_map
                    |from  smart_ptr cimport shared_ptr
                    |from  AutowrapRefHolder cimport AutowrapRefHolder
+                   |from  AutowrapPtrHolder cimport AutowrapPtrHolder
+                   |from  AutowrapConstPtrHolder cimport AutowrapConstPtrHolder
                    |from  libcpp cimport bool
                    |from  libc.string cimport const_char
                    |from cython.operator cimport dereference as deref,

--- a/autowrap/data_files/autowrap/AutowrapConstPtrHolder.pxd
+++ b/autowrap/data_files/autowrap/AutowrapConstPtrHolder.pxd
@@ -1,0 +1,11 @@
+
+cdef extern from "autowrap_tools.hpp" namespace "autowrap":
+
+    cdef cppclass AutowrapConstPtrHolder[T]:
+
+        AutowrapConstPtrHolder()
+        AutowrapConstPtrHolder(const T *)
+        const T * get()
+        void assign(const T *)
+
+

--- a/autowrap/data_files/autowrap/AutowrapPtrHolder.pxd
+++ b/autowrap/data_files/autowrap/AutowrapPtrHolder.pxd
@@ -1,0 +1,11 @@
+
+cdef extern from "autowrap_tools.hpp" namespace "autowrap":
+
+    cdef cppclass AutowrapPtrHolder[T]:
+
+        AutowrapPtrHolder()
+        AutowrapPtrHolder(T *)
+        T * get()
+        void assign(T *)
+
+

--- a/autowrap/data_files/autowrap/AutowrapRefHolder.pxd
+++ b/autowrap/data_files/autowrap/AutowrapRefHolder.pxd
@@ -5,3 +5,4 @@ cdef extern from "autowrap_tools.hpp" namespace "autowrap":
 
         AutowrapRefHolder(T &)
         void assign(T &)
+

--- a/autowrap/data_files/autowrap/autowrap_tools.hpp
+++ b/autowrap/data_files/autowrap/autowrap_tools.hpp
@@ -33,7 +33,58 @@ namespace autowrap {
             {
                 _ref = refneu;
             }
+    };
 
+    template <class X>
+    class AutowrapPtrHolder {
+
+        private:
+
+            X* _ptr;
+
+        public:
+
+            AutowrapPtrHolder() {}
+
+            AutowrapPtrHolder(X *ref): _ptr(ref) 
+            {
+            }
+
+            X* get()
+            {
+                return _ptr;
+            }
+
+            void assign(X * ptr)
+            {
+                _ptr = ptr;
+            }
+    };
+
+    template <class X>
+    class AutowrapConstPtrHolder {
+
+        private:
+
+            const X* _ptr;
+
+        public:
+
+            AutowrapConstPtrHolder() {}
+
+            AutowrapConstPtrHolder(const X *ref): _ptr(ref) 
+            {
+            }
+
+            const X* get()
+            {
+                return _ptr;
+            }
+
+            void assign(const X * ptr)
+            {
+                _ptr = ptr;
+            }
     };
 
 };


### PR DESCRIPTION
- allows classes to manage their memory themselves
- they can still provide a small wrapper as self.inst to hold a ptr to
  the class


this would then look like this (addons/pyx)

```
    # NOTE: using shared_ptr for a singleton will lead to segfaults, use raw ptr instead
    cdef AutowrapConstPtrHolder[_ElementDB] inst

    def __init__(self):
      self.inst = AutowrapConstPtrHolder[_ElementDB](_getInstance_ElementDB())
```

and all other methods get automatically wrapped and they will have access to an instance of the object through `self.inst.get()`, e.g. everything else will work exactly as expected...

this will be useful for singleton objects which provide a static method to get a ptr, e.g. `ElementDB::getInstance`