### PR TITLE
introduce a flexible string type which automatically handles unicode and byte objects

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -981,6 +981,7 @@ class CodeGenerator(object):
         code.add("""
                    |#cython: c_string_encoding=ascii  # for cython>=0.19
                    |from  libcpp.string  cimport string as libcpp_string
+                   |from  libcpp.string  cimport string as libcpp_utf8_string
                    |from  libcpp.set     cimport set as libcpp_set
                    |from  libcpp.vector  cimport vector as libcpp_vector
                    |from  libcpp.pair    cimport pair as libcpp_pair

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -1410,6 +1410,27 @@ class StdStringConverter(TypeConverterBase):
         return "%s = <libcpp_string>%s" % (output_py_var, input_cpp_var)
 
 
+class StdStringUnicodeConverter(StdStringConverter):
+    def get_base_types(self):
+        return "libcpp_utf8_string",
+
+    def matching_python_type(self, cpp_type):
+        return ""
+
+    def input_conversion(self, cpp_type, argument_var, arg_num):
+        code = Code()
+        code.add("""
+            |if isinstance($argument_var, unicode):
+            |    $argument_var = $argument_var.encode('utf-8')
+            """, locals())
+        call_as = "(<libcpp_string>%s)" % argument_var
+        cleanup = ""
+        return code, call_as, cleanup
+
+    def type_check_expression(self, cpp_type, argument_var):
+        return "isinstance(%s, (bytes, unicode))" % argument_var
+
+
 class SharedPtrConverter(TypeConverterBase):
 
     """
@@ -1492,6 +1513,7 @@ def setup_converter_registry(classes_to_wrap, enums_to_wrap, instance_map):
     converters.register(CharPtrConverter())
     converters.register(CharConverter())
     converters.register(StdStringConverter())
+    converters.register(StdStringUnicodeConverter())
     converters.register(StdVectorConverter())
     converters.register(StdSetConverter())
     converters.register(StdMapConverter())

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -803,6 +803,29 @@ def test_gil_unlock():
     assert g.get_greetings() == b"Hello Jack, How are you?"
 
 
+def test_automatic_string_conversion():
+    target = os.path.join(test_files, "libcpp_utf8_string_test.pyx")
+    include_dirs = autowrap.parse_and_generate_code(["libcpp_utf8_string_test.pxd"],
+                                                    root=test_files, target=target,  debug=True)
+
+    wrapped = autowrap.Utils.compile_and_import("libcpp_utf8_string_wrapped", [target, ],
+                                                include_dirs)
+    h = wrapped.Hello()
+
+    input_bytes = b"J\xc3\xbcrgen"
+    input_unicode = b"J\xc3\xbcrgen".decode('utf-8')
+
+    expected = b"Hello J\xc3\xbcrgen"
+
+    msg = h.get(input_bytes)
+    assert isinstance(msg, bytes)
+    assert msg == expected
+
+    msg = h.get(input_unicode)
+    assert isinstance(msg, bytes)
+    assert msg == expected
+
+
 # todo: wrapped tempaltes as input of free functions and mehtods of other
 # classes
 #

--- a/tests/test_files/libcpp_utf8_string_test.hpp
+++ b/tests/test_files/libcpp_utf8_string_test.hpp
@@ -1,0 +1,12 @@
+#include <string>
+
+
+class Hello {
+    public:
+
+        Hello(){}
+        std::string get(const std::string& s) const {
+            std::string msg = "Hello " + s;
+                return msg;
+        }
+};

--- a/tests/test_files/libcpp_utf8_string_test.pxd
+++ b/tests/test_files/libcpp_utf8_string_test.pxd
@@ -1,0 +1,8 @@
+from libcpp.string cimport string as libcpp_utf8_string
+from libcpp.string cimport string as libcpp_string
+
+
+cdef extern from "libcpp_utf8_string_test.hpp":
+    cdef cppclass Hello:
+        Hello()
+        libcpp_string get(libcpp_utf8_string)


### PR DESCRIPTION
@uweschmitt @hroest 

This PR implements a flexible string type which automatically handles encoding conversion if necessary, so that you can call methods that take a string with either a byte string or a unicode string. 

The behaviour for string output remains the same, which is whatever default python prefers (2.x bytes, 3.x unicode/str).

Implementation:

I do not change the libcpp_string type, but introduced a libcpp_utf8_string type, so you can decide if you want the behaviour or not.