### PR TITLE
use existing conversion providers if possible

### DIFF
--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -641,8 +641,6 @@ class StdMapConverter(TypeConverterBase):
         key_conv_code = ""
         key_conv_cleanup = ""
 
-        tt_key, tt_value = cpp_type.template_args
-
         if cy_tt_value.is_enum:
             value_conv = "<%s> value" % cy_tt_value
         elif tt_value.base_type in self.converters.names_of_wrapper_classes:

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -825,6 +825,15 @@ def test_automatic_string_conversion():
     assert isinstance(msg, bytes)
     assert msg == expected
 
+    input_greet_bytes = b"Hall\xc3\xb6chen"
+    input_greet_unicode = input_greet_bytes.decode('utf-8')
+
+    expected = b"Hall\xc3\xb6chen J\xc3\xbcrgen"
+
+    msg = h.get_more({"greet": input_greet_unicode, "name": input_bytes})
+    assert isinstance(msg, bytes)
+    assert msg == expected
+
 
 # todo: wrapped tempaltes as input of free functions and mehtods of other
 # classes

--- a/tests/test_files/libcpp_utf8_string_test.hpp
+++ b/tests/test_files/libcpp_utf8_string_test.hpp
@@ -1,12 +1,26 @@
 #include <string>
+#include <sstream>
+#include <map>
 
 
 class Hello {
     public:
 
         Hello(){}
+
         std::string get(const std::string& s) const {
             std::string msg = "Hello " + s;
-                return msg;
+            return msg;
+        }
+
+        std::string get_more(std::map<std::string, std::string>& m) const {
+            if (m.count("greet") == 0 || m.count("name") == 0) {
+                return "Hey, be friendly!";
+            }
+
+            std::ostringstream oss;
+            oss << m["greet"] << " " << m["name"];
+
+            return oss.str();
         }
 };

--- a/tests/test_files/libcpp_utf8_string_test.pxd
+++ b/tests/test_files/libcpp_utf8_string_test.pxd
@@ -1,8 +1,9 @@
 from libcpp.string cimport string as libcpp_utf8_string
 from libcpp.string cimport string as libcpp_string
-
+from libcpp.map cimport map as libcpp_map
 
 cdef extern from "libcpp_utf8_string_test.hpp":
     cdef cppclass Hello:
         Hello()
         libcpp_string get(libcpp_utf8_string)
+        libcpp_string get_more(libcpp_map[libcpp_utf8_string, libcpp_utf8_string])


### PR DESCRIPTION
@uweschmitt @hroest 

This PR reuses existing conversion providers for conversion of dicts aka libcpp_map if applicable, e.g. 

libcpp_map[libcpp_utf8_string, libcpp_utf8_string]

I will provide some test cases, but maybe you can already take a look let me know what you think / if he approach is ok.