### PR TITLE
Feature/nested maps

### DIFF
--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -265,6 +265,18 @@ def test_libcpp():
     t.process21(d1, {42: 11})
     assert d1.get(1) == 11
 
+    d1 = dict()
+    t.process211(d1, {"42": [11, 6]})
+    assert d1.get(1) == 11
+
+    d2 = dict()
+    t.process212(d2, {"42": [ [11, 6], [2] , [8] ]})
+    assert d2.get(1) == 11
+
+    d3 = dict()
+    t.process214(d3, {"42": [ [11, 6], [2, 8] ]})
+    assert d3.get(1) == 11
+
     d1 = set((42,))
     d2 = set()
     t.process22(d1, d2)

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -266,15 +266,15 @@ def test_libcpp():
     assert d1.get(1) == 11
 
     d1 = dict()
-    t.process211(d1, {"42": [11, 6]})
+    t.process211(d1, {b"42": [11, 6]})
     assert d1.get(1) == 11
 
     d2 = dict()
-    t.process212(d2, {"42": [ [11, 6], [2] , [8] ]})
+    t.process212(d2, {b"42": [ [11, 6], [2] , [8] ]})
     assert d2.get(1) == 11
 
     d3 = dict()
-    t.process214(d3, {"42": [ [11, 6], [2, 8] ]})
+    t.process214(d3, {b"42": [ [11, 6], [2, 8] ]})
     assert d3.get(1) == 11
 
     d1 = set((42,))

--- a/tests/test_files/libcpp_test.hpp
+++ b/tests/test_files/libcpp_test.hpp
@@ -206,6 +206,30 @@ class LibCppTest {
             in[1] = (float) arg2[42];
         }
 
+        void  process211(std::map<int, float> & in, std::map<std::string, std::vector<int> > & arg2)
+        {
+            std::string test_str("42");
+            in[1] = (float) arg2[test_str][0];
+        }
+
+        void  process212(std::map<int, float> & in, std::map<std::string, std::vector< std::vector<int> > > & arg2)
+        {
+            std::string test_str("42");
+            in[1] = (float) arg2[test_str][0][0];
+        }
+
+        void  process213(std::map<int, float> & in, std::map<std::string, std::vector< std::vector<Int> > > & arg2)
+        {
+            std::string test_str("42");
+            in[1] = (float) arg2[test_str][0][0].i_;
+        }
+
+        void  process214(std::map<int, float> & in, std::map<std::string, std::vector< std::pair<int, int> > > & arg2)
+        {
+            std::string test_str("42");
+            in[1] = (float) arg2[test_str][0].first;
+        }
+
         void  process22(std::set<int> & in, std::set<float> & arg2)
         {
             std::set<int>::iterator it = in.begin();

--- a/tests/test_files/libcpp_test.pxd
+++ b/tests/test_files/libcpp_test.pxd
@@ -89,6 +89,10 @@ cdef extern from "libcpp_test.hpp":
         void  process20(libcpp_map[int, float] & in_)
 
         void  process21(libcpp_map[int, float] & in_, libcpp_map[int,int] & arg2)
+        void  process211(libcpp_map[int, float] & in_, libcpp_map[libcpp_string, libcpp_vector[int] ] & arg2)
+        void  process212(libcpp_map[int, float] & in_, libcpp_map[libcpp_string, libcpp_vector[ libcpp_vector[int] ] ] & arg2)
+        # void  process213(libcpp_map[int, float] & in_, libcpp_map[libcpp_string, libcpp_vector[ libcpp_vector[Int] ] ] & arg2)
+        void  process214(libcpp_map[int, float] & in_, libcpp_map[libcpp_string, libcpp_vector[ libcpp_pair[int, int] ] ] & arg2)
         void  process22(libcpp_set[int] &, libcpp_set[float] &)
         void  process23(libcpp_vector[int] &, libcpp_vector[float] &)
         void  process24(libcpp_pair[int, float] & in_, libcpp_pair[int,int] & arg2)


### PR DESCRIPTION
- allow wrapping of some simple nested maps, e.g. `std::map< int, std::vector<double> > ` and further nesting of simple types such as  `std::map< int, std::vector< std::pair<double, int> > > `