### PR TITLE
[DOC] embed docstring into Cython code

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -488,7 +488,12 @@ class CodeGenerator(object):
         if not is_free_fun:
             py_signature_parts.insert(0, "self")
 
+        # Prepare docstring
         docstring = "Cython signature: %s" % method
+        extra_doc = method.cpp_decl.annotations.get("wrap-doc", "")
+        if len(extra_doc) > 0:
+            docstring += "\n" + extra_doc
+
         py_signature = ", ".join(py_signature_parts)
         code.add("""
                    |

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -487,10 +487,13 @@ class CodeGenerator(object):
         # Step 1: create method decl statement
         if not is_free_fun:
             py_signature_parts.insert(0, "self")
+
+        docstring = "Cython signature: %s" % method
         py_signature = ", ".join(py_signature_parts)
         code.add("""
                    |
                    |def $py_name($py_signature):
+                   |    \"\"\"$docstring\"\"\"
                    """, locals())
 
         # Step 2a: create code which convert python input args to c++ args of
@@ -990,8 +993,12 @@ class CodeGenerator(object):
 
     def create_std_cimports(self):
         code = Code.Code()
+        # Using embedsignature here does not help much as it is only the Python
+        # signature which does not really specify the argument types. We have
+        # to use a docstring for each method.
         code.add("""
                    |#cython: c_string_encoding=ascii  # for cython>=0.19
+                   |#cython: embedsignature=False
                    |from  libcpp.string  cimport string as libcpp_string
                    |from  libcpp.string  cimport string as libcpp_utf8_string
                    |from  libcpp.set     cimport set as libcpp_set

--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -114,16 +114,22 @@ def parse_line_annotations(node, lines):
     for line in lines[start:end]:
         __, __, comment = line.partition("#")
         if comment:
-            for f in comment.split(" "):
-                f = f.strip()
+            key = None
+            for f_ in comment.split(" "):
+                f = f_.strip()
                 if not f:
                     continue
                 if ":" in f:
                     key, value = f.split(":", 1)
                     assert value.strip(), "empty value for key '%s'" % key
-                else:
+                    result[key] = value
+                elif f.find("wrap-") != -1:
                     key, value = f, True
-                result[key] = value
+                    result[key] = value
+                elif key is not None:
+                    # they belong to the previous key
+                    value = " " + f_
+                    result[key] += value
     return result
 
 

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -173,6 +173,8 @@ def test_libcpp():
     li2 = t.process(li)
     assert li == li2 == [1, 42]
 
+    assert t.twist.__doc__.find("Dont forget this stuff") != -1
+
     in1 = [1, 2]
     out = t.process2(in1)
     assert out == in1 == [42, 11]

--- a/tests/test_files/libcpp_test.pxd
+++ b/tests/test_files/libcpp_test.pxd
@@ -57,7 +57,7 @@ cdef extern from "libcpp_test.hpp":
 
         int  get() #wrap-as:gett
 
-        libcpp_pair[int,libcpp_string] twist(libcpp_pair[libcpp_string, int])
+        libcpp_pair[int,libcpp_string] twist(libcpp_pair[libcpp_string, int]) #wrap-doc:Dont forget this stuff here!
         libcpp_vector[int] process(libcpp_vector[int] &)
 
         libcpp_pair[int, int] process2(libcpp_pair[int, int] &)


### PR DESCRIPTION
this embeds the Cython docstring into the wrapped methods which can be useful if you quickly want to check how to call a specific method:

```
$ python -c "import libcpp; help(libcpp.LibCppTest.twist)"
Help on method_descriptor:

twist(...)
    Cython signature: libcpp_pair[int,libcpp_string] twist(libcpp_pair[libcpp_string,int])
```

whereas before it would simply have said `twist(...)` which is not very helpful. With this, it becomes pretty clear what the signature is, what the fxn returns and what arguments it expects.