### PR TITLE
Feature/pxd files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ python:
   - "3.5"
   - "3.6"
 install:
+  - pip install -U Cython
   - travis_retry python setup.py develop
 script: "py.test tests/"

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -103,6 +103,10 @@ class CodeGenerator(object):
         self.manual_code = manual_code
         self.extra_cimports = extra_cimports
 
+        self.include_shared_ptr=True
+        self.include_refholder=True
+        self.include_numpy=False
+
         self.target_path = os.path.abspath(pyx_target_path)
         self.target_pxd_path = self.target_path.split(".pyx")[0] + ".pxd"
         self.target_dir = os.path.dirname(self.target_path)
@@ -1148,16 +1152,29 @@ class CodeGenerator(object):
                    |from  libcpp.vector  cimport vector as libcpp_vector
                    |from  libcpp.pair    cimport pair as libcpp_pair
                    |from  libcpp.map     cimport map  as libcpp_map
-                   |from  smart_ptr cimport shared_ptr
-                   |from  AutowrapRefHolder cimport AutowrapRefHolder
-                   |from  AutowrapPtrHolder cimport AutowrapPtrHolder
-                   |from  AutowrapConstPtrHolder cimport AutowrapConstPtrHolder
                    |from  libcpp cimport bool
                    |from  libc.string cimport const_char
                    |from cython.operator cimport dereference as deref,
                    + preincrement as inc, address as address
-
                    """)
+        if self.include_refholder:
+            code.add("""
+                   |from  AutowrapRefHolder cimport AutowrapRefHolder
+                   |from  AutowrapPtrHolder cimport AutowrapPtrHolder
+                   |from  AutowrapConstPtrHolder cimport AutowrapConstPtrHolder
+                   """
+        if self.include_shared_ptr:
+            code.add("""
+                   |from  smart_ptr cimport shared_ptr
+                   """
+        if self.include_numpy:
+            code.add("""
+                   |cimport numpy as np
+                   |import numpy as np
+                   |cimport numpy as numpy
+                   |import numpy as numpy
+                   """
+
         return code
 
     def create_std_cimports(self):

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1162,18 +1162,18 @@ class CodeGenerator(object):
                    |from  AutowrapRefHolder cimport AutowrapRefHolder
                    |from  AutowrapPtrHolder cimport AutowrapPtrHolder
                    |from  AutowrapConstPtrHolder cimport AutowrapConstPtrHolder
-                   """
+                   """)
         if self.include_shared_ptr:
             code.add("""
                    |from  smart_ptr cimport shared_ptr
-                   """
+                   """)
         if self.include_numpy:
             code.add("""
                    |cimport numpy as np
                    |import numpy as np
                    |cimport numpy as numpy
                    |import numpy as numpy
-                   """
+                   """)
 
         return code
 

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -94,8 +94,8 @@ class CodeGenerator(object):
     ConversionProviders for each argument type.
     """
 
-    def __init__(self, resolved, instance_mapping, target_path=None,
-                 manual_code=None, extra_cimports=None):
+    def __init__(self, resolved, instance_mapping, pyx_target_path=None,
+                 manual_code=None, extra_cimports=None, allDecl={}):
 
         if manual_code is None:
             manual_code = dict()
@@ -103,9 +103,12 @@ class CodeGenerator(object):
         self.manual_code = manual_code
         self.extra_cimports = extra_cimports
 
-        self.target_path = os.path.abspath(target_path)
+        self.target_path = os.path.abspath(pyx_target_path)
+        self.target_pxd_path = self.target_path.split(".pyx")[0] + ".pxd"
         self.target_dir = os.path.dirname(self.target_path)
+        self.write_pxd = len(allDecl) > 0
 
+        ## Step 1: get all classes of current module
         self.classes = [d for d in resolved if isinstance(d, ResolvedClass)]
         self.enums = [d for d in resolved if isinstance(d, ResolvedEnum)]
         self.functions = [d for d in resolved if isinstance(d, ResolvedFunction)]
@@ -118,11 +121,38 @@ class CodeGenerator(object):
         self.resolved.extend(sorted(self.classes, key=lambda d: d.name))
 
         self.instance_mapping = instance_mapping
+        self.allDecl = allDecl
 
-        self.cr = setup_converter_registry(self.classes, self.enums, instance_mapping)
+        ## Step 2: get classes of complete project (includes other modules)
+        self.all_typedefs = self.typedefs
+        self.all_enums = self.enums
+        self.all_functions = self.functions
+        self.all_classes = self.classes
+        self.all_resolved = self.resolved
+        if len(allDecl) > 0:
+            
+            self.all_typedefs = []
+            self.all_enums = []
+            self.all_functions = []
+            self.all_classes = []
+            for modname, v in allDecl.items():
+                self.all_classes.extend( [d for d in v["decls"] if isinstance(d, ResolvedClass)] )
+                self.all_enums.extend( [d for d in v["decls"] if isinstance(d, ResolvedEnum)] )
+                self.all_functions.extend( [d for d in v["decls"] if isinstance(d, ResolvedFunction)] )
+                self.all_typedefs.extend( [d for d in v["decls"] if isinstance(d, ResolvedTypeDef)] )
+
+            self.all_resolved = []
+            self.all_resolved.extend(sorted(self.all_typedefs, key=lambda d: d.name))
+            self.all_resolved.extend(sorted(self.all_enums, key=lambda d: d.name))
+            self.all_resolved.extend(sorted(self.all_functions, key=lambda d: d.name))
+            self.all_resolved.extend(sorted(self.all_classes, key=lambda d: d.name))
+
+        # Register using all classes so that we know about the complete project
+        self.cr = setup_converter_registry(self.all_classes, self.enums, instance_mapping)
 
         self.top_level_code = []
         self.class_codes = defaultdict(list)
+        self.class_pxd_codes = defaultdict(list)
         self.wrapped_enums_cnt = 0
         self.wrapped_classes_cnt = 0
         self.wrapped_methods_cnt = 0
@@ -136,7 +166,7 @@ class CodeGenerator(object):
     def setup_cimport_paths(self):
 
         pxd_dirs = set()
-        for inst in self.classes + self.enums + self.functions + self.typedefs:
+        for inst in self.all_classes + self.all_enums + self.all_functions + self.all_typedefs:
             pxd_path = os.path.abspath(inst.cpp_decl.pxd_path)
             pxd_dir = os.path.dirname(pxd_path)
             pxd_dirs.add(pxd_dir)
@@ -156,6 +186,7 @@ class CodeGenerator(object):
         """
         self.setup_cimport_paths()
         self.create_cimports()
+        self.create_foreign_cimports()
         self.create_includes()
 
         def create_for(clz, method):
@@ -171,24 +202,41 @@ class CodeGenerator(object):
         create_for(ResolvedEnum, self.create_wrapper_for_enum)
         create_for(ResolvedFunction, self.create_wrapper_for_free_function)
 
-        code = "\n".join(ci.render() for ci in self.top_level_code)
-        code += " \n"
+        # Create code for the pyx file
+        if self.write_pxd:
+            pyx_code = self.create_default_cimports().render()
+        else:
+            pyx_code = "\n".join(ci.render() for ci in self.top_level_code)
+
+        pyx_code += " \n"
         names = set()
         for n, c in self.class_codes.items():
-            code += c.render()
-            code += " \n"
+            pyx_code += c.render()
+            pyx_code += " \n"
             names.add(n)
 
         # manual code which does not extend wrapped classes:
         for name, c in self.manual_code.items():
             if name not in names:
-                code += c.render()
-            code += " \n"
+                pyx_code += c.render()
+            pyx_code += " \n"
+
+        # Create code for the pxd file
+        pxd_code = "\n".join(ci.render() for ci in self.top_level_code)
+        pxd_code += " \n"
+        for n, c in self.class_pxd_codes.items():
+            pxd_code += c.render()
+            pxd_code += " \n"
 
         if debug:
-            print(code)
+            print(pxd_code)
+            print(pyx_code)
         with open(self.target_path, "w") as fp:
-            fp.write(code)
+            fp.write(pyx_code)
+
+        if self.write_pxd:
+            with open(self.target_pxd_path, "w") as fp:
+                fp.write(pxd_code)
 
     def filterout_iterators(self, methods):
         def parse(anno):
@@ -256,19 +304,37 @@ class CodeGenerator(object):
             self.class_codes[class_name].add(code)
 
     def create_wrapper_for_class(self, r_class):
-        """Create Cython code for a single class"""
+        """Create Cython code for a single class
+        
+        Note that the cdef class definition and the member variables go into
+        the .pxd file while the Python-level implementation goes into the .pyx
+        file. This allows us to cimport these classes later across modules.
+
+        """
         self.wrapped_classes_cnt += 1
         self.wrapped_methods_cnt += len(r_class.methods)
         cname = r_class.name
         L.info("create wrapper for class %s" % cname)
         cy_type = self.cr.cython_type(cname)
+        class_pxd_code = Code.Code()
         class_code = Code.Code()
         if r_class.methods and not r_class.wrap_manual_memory:
+            shared_ptr_inst = "cdef shared_ptr[%s] inst" % cy_type
+            if self.write_pxd:
+                class_pxd_code.add("""
+                                |
+                                |cdef class $cname:
+                                |
+                                |    $shared_ptr_inst
+                                |
+                                """, locals())
+                shared_ptr_inst = "" # do not implement in pyx file, only in pxd file
+
             class_code.add("""
                             |
                             |cdef class $cname:
                             |
-                            |    cdef shared_ptr[$cy_type] inst
+                            |    $shared_ptr_inst
                             |
                             |    def __dealloc__(self):
                             |         self.inst.reset()
@@ -291,6 +357,7 @@ class CodeGenerator(object):
                             |
                             """ % r_class.wrap_hash[0], locals())
 
+        self.class_pxd_codes[cname] = class_pxd_code
         self.class_codes[cname] = class_code
 
         cons_created = False
@@ -977,10 +1044,35 @@ class CodeGenerator(object):
                         """, locals())
         return meth_code
 
+    def create_foreign_cimports(self):
+        """Iterate over foreign modules and import all relevant classes from them
+
+        It is necessary to let Cython know about other autowrap-created classes
+        that may reside in other modules.
+        
+        E.g. if we have module1 containing classA, classB and want to access it
+        through the pxd header, then we need to add:
+
+            from module1 import classA, classB
+        """
+        code = Code.Code()
+        for module in self.allDecl:
+            # We skip our own module
+            if self.target_path.find(module) == -1:
+
+                for resolved in self.allDecl[module]["decls"]:
+                    # We are only interested to import classes that could be
+                    # used in the Cython code in the current module 
+                    if resolved.__class__ in (ResolvedClass, ):
+                        name = resolved.cpp_decl.name
+                        code.add("from $module cimport $name", locals())
+
+        self.top_level_code.append(code)
+
     def create_cimports(self):
         self.create_std_cimports()
         code = Code.Code()
-        for resolved in self.resolved:
+        for resolved in self.all_resolved:
             import_from = resolved.pxd_import_path
             name = resolved.name
             if resolved.__class__ in (ResolvedEnum,):
@@ -996,7 +1088,7 @@ class CodeGenerator(object):
 
         self.top_level_code.append(code)
 
-    def create_std_cimports(self):
+    def create_default_cimports(self):
         code = Code.Code()
         # Using embedsignature here does not help much as it is only the Python
         # signature which does not really specify the argument types. We have
@@ -1020,11 +1112,16 @@ class CodeGenerator(object):
                    + preincrement as inc, address as address
 
                    """)
+        return code
+
+    def create_std_cimports(self):
+        code = self.create_default_cimports()
         if self.extra_cimports is not None:
             for stmt in self.extra_cimports:
                 code.add(stmt)
 
         self.top_level_code.append(code)
+        return code
 
     def create_includes(self):
         code = Code.Code()

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -334,7 +334,7 @@ class CodeGenerator(object):
         class_code = Code.Code()
         if r_class.methods:
             shared_ptr_inst = "cdef shared_ptr[%s] inst" % cy_type
-            if len(r_class.wrap_manual_memory) != 0:
+            if len(r_class.wrap_manual_memory) != 0 and r_class.wrap_manual_memory[0] != "__old-model":
                 shared_ptr_inst = r_class.wrap_manual_memory[0]
             if self.write_pxd:
                 class_pxd_code.add("""

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from autowrap.tools import OrderKeepingDictionary
 
 
+
 __doc__ = """
 
     The methods in this module take the class declarations created by

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -162,7 +162,8 @@ class ResolvedClass(object):
         self.cpp_decl = decl
         # self.items = getattr(decl, "items", [])
         self.wrap_ignore = decl.annotations.get("wrap-ignore", False)
-        self.wrap_manual_memory = decl.annotations.get("wrap-manual-memory", False)
+        self.no_pxd_import = decl.annotations.get("no-pxd-import", False)
+        self.wrap_manual_memory = decl.annotations.get("wrap-manual-memory", [])
         self.wrap_hash = decl.annotations.get("wrap-hash", [])
         self.local_map = local_map
         self.instance_map = instance_map

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -205,9 +205,10 @@ class ResolvedFunction(ResolvedMethod):
 
 def resolve_decls_from_files_single_thread(pathes, root):
     decls = []
-    for path in pathes:
+    for k, path in enumerate(pathes):
         full_path = os.path.join(root, path)
-        L.info("parse %s" % full_path)
+        if k % 50 == 0: 
+            L.info("parsing progress %s out of %s" % (k, len(pathes)))
         decls.extend(PXDParser.parse_pxd_file(full_path))
     return _resolve_decls(decls)
 
@@ -234,9 +235,8 @@ def resolve_decls_from_files_multi_thread(pathes, root, num_processes):
     while len(full_pathes) > 0:
         n_work = len(full_pathes)
         remaining = max(0, n_work - num_processes * CONCURRENT_FILES_PER_CORE)
-        args = [full_pathes.pop() for k in xrange(n_work - remaining)]
-        for a in args:
-            L.info("parse %s" % a)
+        args = [full_pathes.pop() for k in range(n_work - remaining)]
+        L.info("parsing progress %s out of %s" % (len(pathes)-remaining, len(pathes)))
 
         res = pool.map(PXDParser.parse_pxd_file, args)
         for r in res:

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -164,6 +164,12 @@ class ResolvedClass(object):
         self.wrap_ignore = decl.annotations.get("wrap-ignore", False)
         self.no_pxd_import = decl.annotations.get("no-pxd-import", False)
         self.wrap_manual_memory = decl.annotations.get("wrap-manual-memory", [])
+        # fix previous code where we had a bool ... 
+        if self.wrap_manual_memory == True:
+            self.wrap_manual_memory = ["__old-model"]
+        else:
+            self.wrap_manual_memory == []
+        assert( isinstance(self.wrap_manual_memory, list) )
         self.wrap_hash = decl.annotations.get("wrap-hash", [])
         self.local_map = local_map
         self.instance_map = instance_map

--- a/autowrap/Main.py
+++ b/autowrap/Main.py
@@ -193,10 +193,12 @@ def run_cython(inc_dirs, extra_opts, out):
     compile(out, options=options)
 
 
-def create_wrapper_code(decls, instance_map, addons, converters, out, extra_inc_dirs, extra_opts, include_boost=True):
+def create_wrapper_code(decls, instance_map, addons, converters, out, extra_inc_dirs, extra_opts, include_boost=True, allDecl=[]):
     cimports, manual_code = collect_manual_code(addons)
     register_converters(converters)
-    inc_dirs = autowrap.generate_code(decls, instance_map, out, False, manual_code, cimports, include_boost)
+    inc_dirs = autowrap.generate_code(decls, instance_map=instance_map, target=out, 
+            debug=False, manual_code=manual_code, 
+            extra_cimports=cimports, include_boost=include_boost, allDecl=allDecl)
 
     if extra_inc_dirs is not None:
         inc_dirs += extra_inc_dirs

--- a/autowrap/__init__.py
+++ b/autowrap/__init__.py
@@ -52,7 +52,7 @@ def parse(files, root, num_processes=1):
 
 
 def generate_code(decls, instance_map, target, debug=False, manual_code=None,
-                  extra_cimports=None, include_boost=True, allDecl=[]):
+                  extra_cimports=None, include_boost=True, include_numpy=False, allDecl=[]):
 
     import autowrap.CodeGenerator
     gen = CodeGenerator.CodeGenerator(decls,
@@ -61,6 +61,7 @@ def generate_code(decls, instance_map, target, debug=False, manual_code=None,
                                       manual_code=manual_code,
                                       extra_cimports=extra_cimports, 
                                       allDecl=allDecl)
+    gen.include_numpy=include_numpy
     gen.create_pyx_file(debug)
     includes = gen.get_include_dirs(include_boost)
     print("Autwrap has wrapped %s classes, %s methods and %s enums" % (

--- a/autowrap/__init__.py
+++ b/autowrap/__init__.py
@@ -46,9 +46,9 @@ The autowrap process consists of two steps:
 """
 
 
-def parse(files, root):
+def parse(files, root, num_processes=1):
     import autowrap.DeclResolver
-    return DeclResolver.resolve_decls_from_files(files, root)
+    return DeclResolver.resolve_decls_from_files(files, root, num_processes)
 
 
 def generate_code(decls, instance_map, target, debug, manual_code=None,

--- a/autowrap/__init__.py
+++ b/autowrap/__init__.py
@@ -51,15 +51,16 @@ def parse(files, root, num_processes=1):
     return DeclResolver.resolve_decls_from_files(files, root, num_processes)
 
 
-def generate_code(decls, instance_map, target, debug, manual_code=None,
-                  extra_cimports=None, include_boost=True):
+def generate_code(decls, instance_map, target, debug=False, manual_code=None,
+                  extra_cimports=None, include_boost=True, allDecl=[]):
 
     import autowrap.CodeGenerator
     gen = CodeGenerator.CodeGenerator(decls,
                                       instance_map,
-                                      target,
-                                      manual_code,
-                                      extra_cimports)
+                                      pyx_target_path=target,
+                                      manual_code=manual_code,
+                                      extra_cimports=extra_cimports, 
+                                      allDecl=allDecl)
     gen.create_pyx_file(debug)
     includes = gen.get_include_dirs(include_boost)
     print("Autwrap has wrapped %s classes, %s methods and %s enums" % (

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 11, 0)
+__version__ = (0, 12, 0)
 
 # for compatibility with older version:
 version = __version__

--- a/docs/README.md
+++ b/docs/README.md
@@ -230,3 +230,15 @@ which then calls a script building the cpp files
 using the `autowrap.Main.create_wrapper_code` directly. Next, the package is
 built by calling `setup.py`.
 
+Larger projects
+--------------
+
+By default, autowrap will produce a single `.pyx` file which contains a wrapper
+for every class and function provided to autowrap. This has the advantage that
+a single module is produced which contains all the wrapped classes and methods.
+However, for larger projects, this can lead to large .cpp files and problems
+with compilation. It is thus possible to change the default behavior of
+autowrap and split up the compilation into multiple units where each unit
+contains some of the projects classes. For an example on how to do this, see
+`./tests/test_full_library.py`.
+

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
-VERSION = (0, 11, 0)
+VERSION = (0, 12, 0)
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
 
 

--- a/tests/test_decl_resolver.py
+++ b/tests/test_decl_resolver.py
@@ -136,13 +136,14 @@ cdef extern from "A.h":
     assert n == "j"
 
 
-def _resolve(*names):
+def _resolve(*names, **kwargs):
     root = os.path.join(os.path.dirname(__file__), "test_files")
-    return autowrap.DeclResolver.resolve_decls_from_files(names, root=root)
+    num_processes = kwargs.get("num_processes", 1)
+    return autowrap.DeclResolver.resolve_decls_from_files(names, root=root, num_processes=num_processes)
 
 
 def test_simple():
-    (cdcl, enumdcl, f1, f2, f3), map_ = _resolve("minimal.pxd")
+    (cdcl, enumdcl, f1, f2, f3), map_ = _resolve("minimal.pxd", num_processes=1)
 
     assert cdcl.name == "Minimal"
     assert enumdcl.name == "ABCorD"
@@ -152,6 +153,12 @@ def test_simple():
     assert f2.name == "sumup"
     assert f3.name == "run_static"
 
+def test_simple_mp():
+    (cdcl, enumdcl, f1, f2, f3), map_ = _resolve("minimal.pxd", num_processes=2)
+
+    assert cdcl.name == "Minimal"
+    assert enumdcl.name == "ABCorD"
+    assert sorted(map_.keys()) == ["ABCorD", "Minimal"]
 
 def test_singular():
 

--- a/tests/test_files/full_lib/A.hpp
+++ b/tests/test_files/full_lib/A.hpp
@@ -1,0 +1,30 @@
+#include <vector>
+#include <string>
+#include <utility>
+#include <map>
+#include <boost/shared_ptr.hpp>
+
+#ifndef HEADER_A
+#define HEADER_A
+
+enum testA {
+    AA, AAA
+};
+
+
+class Aklass {
+    public:
+        int i_;
+        Aklass(int i): i_(i) { };
+        Aklass(const Aklass & i): i_(i.i_) { };
+};
+
+class A_second {
+    public:
+        int i_;
+        A_second(int i): i_(i) { };
+        A_second(const A_second & i): i_(i.i_) { };
+};
+
+
+#endif

--- a/tests/test_files/full_lib/A.pxd
+++ b/tests/test_files/full_lib/A.pxd
@@ -1,0 +1,23 @@
+from libcpp.string cimport string as libcpp_string
+from libcpp.set cimport set as libcpp_set
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp cimport bool
+from libcpp.pair  cimport pair  as libcpp_pair 
+from libcpp.map  cimport map  as libcpp_map 
+from smart_ptr cimport shared_ptr
+
+cdef extern from "A.hpp":
+
+    cdef enum testA:
+        AA, AAA
+
+    cdef cppclass A_second:
+        int i_
+        A_second(int i)
+        A_second(A_second & i)
+
+    cdef cppclass Aklass:
+        int i_
+        Aklass(int i)
+        Aklass(Aklass & i)
+

--- a/tests/test_files/full_lib/B.hpp
+++ b/tests/test_files/full_lib/B.hpp
@@ -1,0 +1,30 @@
+#include <vector>
+#include <string>
+#include <utility>
+#include <map>
+#include <boost/shared_ptr.hpp>
+
+#ifndef HEADER_B
+#define HEADER_B
+
+enum testB {
+    BB, BBB
+};
+
+
+class Bklass {
+    public:
+        int i_;
+        Bklass(int i): i_(i) { };
+        Bklass(const Bklass & i): i_(i.i_) { };
+};
+
+class B_second {
+    public:
+        int i_;
+        B_second(int i): i_(i) { };
+        B_second(const B_second & i): i_(i.i_) { };
+};
+
+
+#endif

--- a/tests/test_files/full_lib/B.pxd
+++ b/tests/test_files/full_lib/B.pxd
@@ -1,0 +1,23 @@
+from libcpp.string cimport string as libcpp_string
+from libcpp.set cimport set as libcpp_set
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp cimport bool
+from libcpp.pair  cimport pair  as libcpp_pair 
+from libcpp.map  cimport map  as libcpp_map 
+from smart_ptr cimport shared_ptr
+
+cdef extern from "B.hpp":
+
+    cdef enum testB:
+        BB, BBB
+
+    cdef cppclass B_second:
+        int i_
+        B_second(int i)
+        B_second(B_second & i)
+
+    cdef cppclass Bklass:
+        int i_
+        Bklass(int i)
+        Bklass(Bklass & i)
+

--- a/tests/test_files/full_lib/C.hpp
+++ b/tests/test_files/full_lib/C.hpp
@@ -1,0 +1,25 @@
+#include <vector>
+#include <string>
+#include <utility>
+#include <map>
+#include <boost/shared_ptr.hpp>
+
+#ifndef HEADER_C
+#define HEADER_C
+
+class Cklass {
+    public:
+        int i_;
+        Cklass(int i): i_(i) { };
+        Cklass(const Cklass & i): i_(i.i_) { };
+};
+
+class C_second {
+    public:
+        int i_;
+        C_second(int i): i_(i) { };
+        C_second(const C_second & i): i_(i.i_) { };
+};
+
+
+#endif

--- a/tests/test_files/full_lib/C.pxd
+++ b/tests/test_files/full_lib/C.pxd
@@ -1,0 +1,20 @@
+from libcpp.string cimport string as libcpp_string
+from libcpp.set cimport set as libcpp_set
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp cimport bool
+from libcpp.pair  cimport pair  as libcpp_pair 
+from libcpp.map  cimport map  as libcpp_map 
+from smart_ptr cimport shared_ptr
+
+cdef extern from "C.hpp":
+
+    cdef cppclass C_second:
+        int i_
+        C_second(int i)
+        C_second(C_second & i)
+
+    cdef cppclass Cklass:
+        int i_
+        Cklass(int i)
+        Cklass(Cklass & i)
+

--- a/tests/test_files/full_lib/D.hpp
+++ b/tests/test_files/full_lib/D.hpp
@@ -1,0 +1,28 @@
+#include <vector>
+#include <string>
+#include <utility>
+#include <map>
+#include <boost/shared_ptr.hpp>
+
+#include "B.hpp":
+
+#ifndef HEADER_D
+#define HEADER_D
+
+class Dklass {
+    public:
+        int i_;
+        Dklass(int i): i_(i) { };
+        Dklass(const Dklass & i): i_(i.i_) { };
+};
+
+class D_second {
+    public:
+        int i_;
+        D_second(int i): i_(i) { };
+        D_second(const D_second & i): i_(i.i_) { };
+        void runB(const B_second & arg) { i_ = arg.i_;}
+};
+
+
+#endif

--- a/tests/test_files/full_lib/D.pxd
+++ b/tests/test_files/full_lib/D.pxd
@@ -1,0 +1,23 @@
+from libcpp.string cimport string as libcpp_string
+from libcpp.set cimport set as libcpp_set
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp cimport bool
+from libcpp.pair  cimport pair  as libcpp_pair 
+from libcpp.map  cimport map  as libcpp_map 
+from smart_ptr cimport shared_ptr
+
+from B cimport *
+
+cdef extern from "D.hpp":
+
+    cdef cppclass D_second:
+        int i_
+        D_second(int i)
+        D_second(D_second & i)
+        void runB(B_second & i)
+
+    cdef cppclass Dklass:
+        int i_
+        Dklass(int i)
+        Dklass(Dklass & i)
+

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -59,17 +59,17 @@ from Cython.Distutils import build_ext
 
 ext = []
 ext.append( Extension("moduleCD", sources = ['moduleCD.pyx'], language="c++",
-        include_dirs = ['/home/hr/projects/autowrap/autowrap/data_files/autowrap', '/home/hr/projects/autowrap/tests/test_files/full_lib'],
+        include_dirs = %(include_dirs)r,
         extra_compile_args = ['-Wno-unused-but-set-variable'],
         extra_link_args = [],
         ))
 ext.append(Extension("moduleA", sources = ['moduleA.pyx'], language="c++",
-        include_dirs = ['/home/hr/projects/autowrap/autowrap/data_files/autowrap', '/home/hr/projects/autowrap/tests/test_files/full_lib'],
+        include_dirs = %(include_dirs)r,
         extra_compile_args = ['-Wno-unused-but-set-variable'],
         extra_link_args = [],
         ))
 ext.append(Extension("moduleB", sources = ['moduleB.pyx'], language="c++",
-        include_dirs = ['/home/hr/projects/autowrap/autowrap/data_files/autowrap', '/home/hr/projects/autowrap/tests/test_files/full_lib'],
+        include_dirs = %(include_dirs)r,
         extra_compile_args = ['-Wno-unused-but-set-variable'],
         extra_link_args = [],
         ))
@@ -111,7 +111,7 @@ def compile_and_import(names, source_files, include_dirs=None, extra_files=[], *
 
     include_dirs = [os.path.abspath(d) for d in include_dirs]
     source_files = [os.path.basename(f) for f in source_files]
-    setup_code = template 
+    setup_code = template % locals()
     if debug:
         print("\n")
         print("-" * 70)

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -1,0 +1,222 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
+import pytest
+
+__license__ = """
+
+Copyright (c) 2012-2014, Uwe Schmitt, ETH Zurich, all rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the mineway GmbH nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import autowrap.DeclResolver
+import autowrap.CodeGenerator
+import autowrap.PXDParser
+import autowrap.Utils
+import autowrap.Code
+import autowrap.Main
+import autowrap
+
+import os
+import math
+import copy
+
+from .utils import expect_exception
+
+test_files = os.path.join(os.path.dirname(__file__),  "test_files", "full_lib")
+
+template = """
+from distutils.core import setup, Extension
+
+import sys
+import pprint
+
+from Cython.Distutils import build_ext
+
+ext = []
+ext.append( Extension("moduleCD", sources = ['moduleCD.pyx'], language="c++",
+        include_dirs = ['/home/hr/projects/autowrap/autowrap/data_files/autowrap', '/home/hr/projects/autowrap/tests/test_files/full_lib'],
+        extra_compile_args = ['-Wno-unused-but-set-variable'],
+        extra_link_args = [],
+        ))
+ext.append(Extension("moduleA", sources = ['moduleA.pyx'], language="c++",
+        include_dirs = ['/home/hr/projects/autowrap/autowrap/data_files/autowrap', '/home/hr/projects/autowrap/tests/test_files/full_lib'],
+        extra_compile_args = ['-Wno-unused-but-set-variable'],
+        extra_link_args = [],
+        ))
+ext.append(Extension("moduleB", sources = ['moduleB.pyx'], language="c++",
+        include_dirs = ['/home/hr/projects/autowrap/autowrap/data_files/autowrap', '/home/hr/projects/autowrap/tests/test_files/full_lib'],
+        extra_compile_args = ['-Wno-unused-but-set-variable'],
+        extra_link_args = [],
+        ))
+
+setup(cmdclass = {'build_ext' : build_ext},
+      name="moduleCD",
+      version="0.0.1",
+      ext_modules = ext
+     )
+
+"""
+
+def compile_and_import(names, source_files, include_dirs=None, extra_files=[], **kws):
+
+    if include_dirs is None:
+        include_dirs = []
+
+    debug = kws.get("debug")
+    import os.path
+    import shutil
+    import tempfile
+    import subprocess
+    import sys
+
+    tempdir = tempfile.mkdtemp()
+    if debug:
+        print("\n")
+        print("tempdir=", tempdir)
+        print("\n")
+    for source_file in source_files:
+        shutil.copy(source_file, tempdir)
+    for extra_file in extra_files:
+        shutil.copy(extra_file, tempdir)
+
+    if sys.platform != "win32":
+        compile_args = "'-Wno-unused-but-set-variable'"
+    else:
+        compile_args = ""
+
+    include_dirs = [os.path.abspath(d) for d in include_dirs]
+    source_files = [os.path.basename(f) for f in source_files]
+    setup_code = template 
+    if debug:
+        print("\n")
+        print("-" * 70)
+        print(setup_code)
+        print("-" * 70)
+        print("\n")
+
+    now = os.getcwd()
+    os.chdir(tempdir)
+    with open("setup.py", "w") as fp:
+        fp.write(setup_code)
+
+    import sys
+    sys.path.insert(0, tempdir)
+    if debug:
+        print("\n")
+        print("-" * 70)
+        import pprint
+        pprint.pprint(sys.path)
+        print("-" * 70)
+        print("\n")
+
+    assert subprocess.Popen("%s setup.py build_ext --force --inplace" % sys.executable, shell=True).wait() == 0
+
+    results = []
+    for name in names:
+        print("BUILT")
+        result = __import__(name)
+        print("imported")
+        if debug:
+            print("imported", result)
+        results.append(result)
+
+    sys.path = sys.path[1:]
+    os.chdir(now)
+    print(results)
+    return results
+
+
+
+def test_full_lib():
+
+    target_mA = os.path.join(test_files, "moduleA.pyx")
+    target_mB = os.path.join(test_files, "moduleB.pyx")
+    target_mCD = os.path.join(test_files, "moduleCD.pyx")
+
+    mnames = ["moduleA", "moduleB", "moduleCD"]
+
+    PY_NUM_THREADS = 1
+    pxd_files = ["A.pxd", "B.pxd", "C.pxd", "D.pxd"]
+    full_pxd_files = [ os.path.join(test_files, f) for f in pxd_files]
+    decls, instance_map = autowrap.parse(full_pxd_files, ".", num_processes=int(PY_NUM_THREADS))
+
+    # Perform mapping
+    pxd_decl_mapping = {}
+    for de in decls:
+        tmp = pxd_decl_mapping.get(de.cpp_decl.pxd_path, []) 
+        tmp.append(de)
+        pxd_decl_mapping[ de.cpp_decl.pxd_path] = tmp 
+
+    # assert len(decls) == 10, len(decls)
+
+    allDecl_mapping = {}
+    allDecl_mapping[mnames[0]] = {"decls" : pxd_decl_mapping[ full_pxd_files[0] ], "addons" : [], "files" : [ full_pxd_files[0] ]}
+    allDecl_mapping[mnames[1]] = {"decls" : pxd_decl_mapping[ full_pxd_files[1] ], "addons" : [], "files" : [ full_pxd_files[1] ]}
+    allDecl_mapping[mnames[2]] = {"decls" : pxd_decl_mapping[ full_pxd_files[2] ] + pxd_decl_mapping[ full_pxd_files[3] ], "addons" : [], "files" : [ full_pxd_files[2] ] + [full_pxd_files[3] ]}
+    print(allDecl_mapping)
+
+    converters = []
+    for modname in mnames:
+        m_filename = "%s.pyx" % modname
+        cimports, manual_code = autowrap.Main.collect_manual_code(allDecl_mapping[modname]["addons"])
+        autowrap.Main.register_converters(converters)
+        autowrap_include_dirs = autowrap.generate_code(allDecl_mapping[modname]["decls"], instance_map,
+                                                       target=m_filename, debug=False, manual_code=manual_code,
+                                                       extra_cimports=cimports,
+                                                       include_boost=False, allDecl=allDecl_mapping)
+        allDecl_mapping[modname]["inc_dirs"] = autowrap_include_dirs
+
+
+
+    for modname in mnames:
+        m_filename = "%s.pyx" % modname
+        autowrap_include_dirs = allDecl_mapping[modname]["inc_dirs"]
+        autowrap.Main.run_cython(inc_dirs=autowrap_include_dirs, extra_opts=None, out=m_filename)
+
+
+    all_pyx_files = ["%s.pyx" % modname  for modname in mnames]
+    all_pxd_files = ["%s.pxd" % modname  for modname in mnames]
+    include_dirs = allDecl_mapping[modname]["inc_dirs"]
+    print (include_dirs)
+    moduleA, moduleB, moduleCD = compile_and_import(mnames, all_pyx_files, include_dirs, extra_files=all_pxd_files)
+
+
+    print (moduleA)
+    print (moduleB)
+
+    Bobj = moduleB.Bklass(5)
+    Bsecond = moduleB.B_second(8)
+    assert Bsecond.i_ == 8
+
+    Dsecond = moduleCD.D_second(11)
+    assert Dsecond.i_ == 11
+    Dsecond.runB(Bsecond)
+    assert Dsecond.i_ == 8
+
+if __name__ == "__main__":
+    test_libcpp()

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -212,7 +212,7 @@ def test_full_lib():
         autowrap_include_dirs = autowrap.generate_code(masterDict[modname]["decls"], instance_map,
                                                        target=m_filename, debug=False, manual_code=manual_code,
                                                        extra_cimports=cimports,
-                                                       include_boost=False, allDecl=masterDict)
+                                                       include_boost=True, allDecl=masterDict)
         masterDict[modname]["inc_dirs"] = autowrap_include_dirs
 
     # Step 4: Generate CPP code

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -153,10 +153,33 @@ def compile_and_import(names, source_files, include_dirs=None, extra_files=[], *
 
 
 def test_full_lib():
+    """
+    Example with multi-file library and multi-file result. 
 
-    target_mA = os.path.join(test_files, "moduleA.pyx")
-    target_mB = os.path.join(test_files, "moduleB.pyx")
-    target_mCD = os.path.join(test_files, "moduleCD.pyx")
+    This shows a full run through of a case where multiple class files (A, B,
+    C, D) with multiple classes in them (Aklass, A_second, etc.) need to be
+    wrapped, a total of 10 different entities over 8 header files (4 hpp and 4
+    pxd files). Autowrap will generate a .pxd and a .pyx file for each module.
+
+    We decided to wrap the library into three modules, A, B and CD to show the
+    capability of autowrap to do that. Note that we have perform multiple steps:
+
+    - Step 1: parse all header files *together* - all pxd files need to be
+              parsed together so that declarations are properly resolved.
+    - Step 2: Map the different parsed entities to the pxd files and the
+              desired modules, we use a master dict here that can be consumed
+              by autowrap and specifies which pxd files and which declarations
+              make up which module.
+    - Step 3: Generate Cython code for each module
+    - Step 4: Generate C++ code for each module (note that Step 3 has to be
+              completed first before we can start to generate C++ code)
+    - Step 5: Compile (run setup.py)
+
+    Note that autowrap gives you full control how many modules you want to
+    produce and which classes go into which modules. It automatically generates
+    correct cimport statements in each so that dependencies between the modules
+    are not an issue.
+    """
 
     mnames = ["moduleA", "moduleB", "moduleCD"]
 


### PR DESCRIPTION
substantial reworking of interna of autowrap:

- we can now produce .pxd files for each compiled module
- each .pxd file contains the header signature of each wrapped class (e.g. `cdef class ABCD` as well as the `shared_ptr` member)
- this allows us to split up the work into multiple modules
- each module `cimports` everything from each other module

this allows us to split up larger libraries (e.g. OpenMS) into individual compilation modules