### PR TITLE
support for nested classes

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -314,7 +314,8 @@ class CodeGenerator(object):
 
         for class_name in decl.cpp_decl.annotations.get("wrap-attach", []):
             code = Code.Code()
-            code.add("%s = %s" % (decl.name, "__" + decl.name))
+            display_name = decl.cpp_decl.annotations.get("wrap-as", [decl.name])[0]
+            code.add("%s = %s" % (display_name, "__" + decl.name))
             self.class_codes[class_name].add(code)
 
     def create_wrapper_for_class(self, r_class):

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -157,6 +157,7 @@ class CodeGenerator(object):
         self.top_level_code = []
         self.top_level_pyx_code = []
         self.class_codes = defaultdict(list)
+        self.class_codes_extra = defaultdict(list)
         self.class_pxd_codes = defaultdict(list)
         self.wrapped_enums_cnt = 0
         self.wrapped_classes_cnt = 0
@@ -206,6 +207,13 @@ class CodeGenerator(object):
         create_for(ResolvedClass, self.create_wrapper_for_class)
         create_for(ResolvedEnum, self.create_wrapper_for_enum)
         create_for(ResolvedFunction, self.create_wrapper_for_free_function)
+
+        # resolve extra
+        for clz, codes in self.class_codes_extra.items():
+            if clz not in self.class_codes:
+                raise Exception("Cannot attach to class", clz, "make sure all wrap-attach are in the same file as parent class")
+            for c in codes:
+                self.class_codes[clz].add(c)
 
         # Create code for the pyx file
         if self.write_pxd:
@@ -329,6 +337,11 @@ class CodeGenerator(object):
         self.wrapped_classes_cnt += 1
         self.wrapped_methods_cnt += len(r_class.methods)
         cname = r_class.name
+        if r_class.cpp_decl.annotations.get("wrap-attach"):
+            pyname = "__" + r_class.name
+        else:
+            pyname = cname
+
         L.info("create wrapper for class %s" % cname)
         cy_type = self.cr.cython_type(cname)
         class_pxd_code = Code.Code()
@@ -340,7 +353,7 @@ class CodeGenerator(object):
             if self.write_pxd:
                 class_pxd_code.add("""
                                 |
-                                |cdef class $cname:
+                                |cdef class $pyname:
                                 |
                                 |    $shared_ptr_inst
                                 |
@@ -350,13 +363,13 @@ class CodeGenerator(object):
             if len(r_class.wrap_manual_memory) != 0:
                 class_code.add("""
                                 |
-                                |cdef class $cname:
+                                |cdef class $pyname:
                                 |
                                 """, locals())
             else:
                 class_code.add("""
                                 |
-                                |cdef class $cname:
+                                |cdef class $pyname:
                                 |
                                 |    $shared_ptr_inst
                                 |
@@ -368,14 +381,14 @@ class CodeGenerator(object):
             # Deal with pure structs (no methods)
             class_pxd_code.add("""
                             |
-                            |cdef class $cname:
+                            |cdef class $pyname:
                             |
                             |    pass
                             |
                             """, locals())
             class_code.add("""
                             |
-                            |cdef class $cname:
+                            |cdef class $pyname:
                             |
                             """, locals())
 
@@ -426,6 +439,15 @@ class CodeGenerator(object):
         extra_methods_code = self.manual_code.get(cname)
         if extra_methods_code:
             class_code.add(extra_methods_code)
+
+
+        for class_name in r_class.cpp_decl.annotations.get("wrap-attach", []):
+            code = Code.Code()
+            display_name = r_class.cpp_decl.annotations.get("wrap-as", [r_class.name])[0]
+            code.add("%s = %s" % (display_name, "__" + r_class.name))
+            tmp = self.class_codes_extra.get(class_name, [])
+            tmp.append(code)
+            self.class_codes_extra[class_name] = tmp
 
     def _create_iter_methods(self, iterators, instance_mapping, local_mapping):
         """
@@ -1117,7 +1139,10 @@ class CodeGenerator(object):
                         # Skip classes that explicitely should not have a pxd
                         # import statement (abstract base classes and the like)
                         if not resolved.no_pxd_import:
-                            code.add("from $module cimport $name", locals())
+                            if resolved.cpp_decl.annotations.get("wrap-attach"):
+                                code.add("from $module cimport __$name", locals())
+                            else:
+                                code.add("from $module cimport $name", locals())
 
             else: 
                 L.info("Skip imports from self (own module %s)" % module)

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 13, 1)
+__version__ = (0, 13, 2)
 
 # for compatibility with older version:
 version = __version__

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
-VERSION = (0, 13, 1)
+VERSION = (0, 13, 2)
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
 
 

--- a/tests/test_files/full_lib/A.hpp
+++ b/tests/test_files/full_lib/A.hpp
@@ -17,6 +17,8 @@ class Aklass {
         int i_;
         Aklass(int i): i_(i) { };
         Aklass(const Aklass & i): i_(i.i_) { };
+
+    enum KlassE { A1, A2, A3};
 };
 
 class A_second {

--- a/tests/test_files/full_lib/A.pxd
+++ b/tests/test_files/full_lib/A.pxd
@@ -17,6 +17,8 @@ cdef extern from "A.hpp":
         A_second(A_second & i)
 
     cdef cppclass Aklass:
+        # wrap-instances:
+        #     Aalias := Aklass
         int i_
         Aklass(int i)
         Aklass(Aklass & i)

--- a/tests/test_files/full_lib/A.pxd
+++ b/tests/test_files/full_lib/A.pxd
@@ -23,3 +23,13 @@ cdef extern from "A.hpp":
         Aklass(int i)
         Aklass(Aklass & i)
 
+    cdef enum A_KlassE "A::KlassE":
+        #wrap-attach:
+        #   Aalias
+        #wrap-instances:
+        #   KlassE := A_KlassE
+        #wrap-as:
+        #   KlassE
+        A1
+        A2
+        A3

--- a/tests/test_files/full_lib/A.pxd
+++ b/tests/test_files/full_lib/A.pxd
@@ -23,7 +23,7 @@ cdef extern from "A.hpp":
         Aklass(int i)
         Aklass(Aklass & i)
 
-    cdef enum A_KlassE "A::KlassE":
+    cdef enum A_KlassE "Aklass::KlassE":
         #wrap-attach:
         #   Aalias
         #wrap-instances:

--- a/tests/test_files/full_lib/B.hpp
+++ b/tests/test_files/full_lib/B.hpp
@@ -7,6 +7,8 @@
 #ifndef HEADER_B
 #define HEADER_B
 
+#include "A.hpp"
+
 enum testB {
     BB, BBB
 };
@@ -24,7 +26,7 @@ class B_second {
         int i_;
         B_second(int i): i_(i) { };
         B_second(const B_second & i): i_(i.i_) { };
+        void processA(const Aklass & a) {i_ = a.i_ + 10;}
 };
-
 
 #endif

--- a/tests/test_files/full_lib/B.hpp
+++ b/tests/test_files/full_lib/B.hpp
@@ -19,6 +19,8 @@ class Bklass {
         int i_;
         Bklass(int i): i_(i) { };
         Bklass(const Bklass & i): i_(i.i_) { };
+
+    enum KlassE { B1, B2, B3};
 };
 
 class B_second {

--- a/tests/test_files/full_lib/B.hpp
+++ b/tests/test_files/full_lib/B.hpp
@@ -21,6 +21,7 @@ class Bklass {
         Bklass(const Bklass & i): i_(i.i_) { };
 
     enum KlassE { B1, B2, B3};
+    struct KlassKlass { int k_; };
 };
 
 class B_second {

--- a/tests/test_files/full_lib/B.pxd
+++ b/tests/test_files/full_lib/B.pxd
@@ -5,6 +5,7 @@ from libcpp cimport bool
 from libcpp.pair  cimport pair  as libcpp_pair 
 from libcpp.map  cimport map  as libcpp_map 
 from smart_ptr cimport shared_ptr
+from A cimport *
 
 cdef extern from "B.hpp":
 
@@ -15,6 +16,7 @@ cdef extern from "B.hpp":
         int i_
         B_second(int i)
         B_second(B_second & i)
+        void processA(Aklass & a)
 
     cdef cppclass Bklass:
         int i_

--- a/tests/test_files/full_lib/B.pxd
+++ b/tests/test_files/full_lib/B.pxd
@@ -34,3 +34,14 @@ cdef extern from "B.hpp":
         B2
         B3
 
+
+    cdef cppclass B_KlassKlass "Bklass::KlassKlass":
+        #wrap-attach:
+        #   Bklass
+        #wrap-instances:
+        #   KlassKlass := B_KlassKlass
+        #wrap-as:
+        #   KlassKlass
+        B_KlassKlass()
+        int k_
+

--- a/tests/test_files/full_lib/B.pxd
+++ b/tests/test_files/full_lib/B.pxd
@@ -23,3 +23,14 @@ cdef extern from "B.hpp":
         Bklass(int i)
         Bklass(Bklass & i)
 
+    cdef enum B_KlassE "B::KlassE":
+        #wrap-attach:
+        #   Bklass
+        #wrap-instances:
+        #   KlassE := B_KlassE
+        #wrap-as:
+        #   KlassE
+        B1
+        B2
+        B3
+

--- a/tests/test_files/full_lib/B.pxd
+++ b/tests/test_files/full_lib/B.pxd
@@ -23,7 +23,7 @@ cdef extern from "B.hpp":
         Bklass(int i)
         Bklass(Bklass & i)
 
-    cdef enum B_KlassE "B::KlassE":
+    cdef enum B_KlassE "Bklass::KlassE":
         #wrap-attach:
         #   Bklass
         #wrap-instances:

--- a/tests/test_files/full_lib/D.hpp
+++ b/tests/test_files/full_lib/D.hpp
@@ -4,7 +4,7 @@
 #include <map>
 #include <boost/shared_ptr.hpp>
 
-#include "B.hpp":
+#include "B.hpp"
 
 #ifndef HEADER_D
 #define HEADER_D

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -189,7 +189,7 @@ def test_full_lib():
     full_pxd_files = [ os.path.join(test_files, f) for f in pxd_files]
     decls, instance_map = autowrap.parse(full_pxd_files, ".", num_processes=int(PY_NUM_THREADS))
 
-    assert len(decls) == 10, len(decls)
+    assert len(decls) == 12, len(decls)
 
     # Step 2: Perform mapping
     pxd_decl_mapping = {}
@@ -233,11 +233,21 @@ def test_full_lib():
     assert Asecond.i_ == 8
     assert Aobj.i_ == 5
 
+    assert Aobj.KlassE is not None
+    assert Aobj.KlassE.A1 is not None
+    assert Aobj.KlassE.A2 is not None
+    assert Aobj.KlassE.A3 is not None
+                        
     Bobj = moduleB.Bklass(5)
     Bsecond = moduleB.B_second(8)
     assert Bsecond.i_ == 8
     Bsecond.processA( Aobj)
     assert Bsecond.i_ == 15
+
+    assert Bobj.KlassE is not None
+    assert Bobj.KlassE.B1 is not None
+    assert Bobj.KlassE.B2 is not None
+    assert Bobj.KlassE.B3 is not None
 
     Bsecond = moduleB.B_second(8)
     Dsecond = moduleCD.D_second(11)

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -228,10 +228,18 @@ def test_full_lib():
     include_dirs = masterDict[modname]["inc_dirs"]
     moduleA, moduleB, moduleCD = compile_and_import(mnames, all_pyx_files, include_dirs, extra_files=all_pxd_files)
 
+    Aobj = moduleA.Aalias(5)
+    Asecond = moduleA.A_second(8)
+    assert Asecond.i_ == 8
+    assert Aobj.i_ == 5
+
     Bobj = moduleB.Bklass(5)
     Bsecond = moduleB.B_second(8)
     assert Bsecond.i_ == 8
+    Bsecond.processA( Aobj)
+    assert Bsecond.i_ == 15
 
+    Bsecond = moduleB.B_second(8)
     Dsecond = moduleCD.D_second(11)
     assert Dsecond.i_ == 11
     Dsecond.runB(Bsecond)

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -189,7 +189,7 @@ def test_full_lib():
     full_pxd_files = [ os.path.join(test_files, f) for f in pxd_files]
     decls, instance_map = autowrap.parse(full_pxd_files, ".", num_processes=int(PY_NUM_THREADS))
 
-    assert len(decls) == 12, len(decls)
+    assert len(decls) == 13, len(decls)
 
     # Step 2: Perform mapping
     pxd_decl_mapping = {}
@@ -248,6 +248,16 @@ def test_full_lib():
     assert Bobj.KlassE.B1 is not None
     assert Bobj.KlassE.B2 is not None
     assert Bobj.KlassE.B3 is not None
+    assert Bobj.KlassKlass is not None
+
+    # there are two different ways to get Bklass::KlassKlass, either through a
+    # Bklass object or through the module
+    Bobj_kk = Bobj.KlassKlass()
+    Bobj_kk.k_ = 14
+    assert Bobj_kk.k_ == 14
+    Bobj_kk = moduleB.Bklass.KlassKlass()
+    Bobj_kk.k_ = 14
+    assert Bobj_kk.k_ == 14
 
     Bsecond = moduleB.B_second(8)
     Dsecond = moduleCD.D_second(11)


### PR DESCRIPTION
Allow classes to be "attached" similar to enums. 

Cleans up the default namespace and creates some hierarchy. Also allows identically named classes to be created by attaching them to different objects, e.g.  ObjA.Klass and ObjB.Klass can now both co-exist.