### PR TITLE
Feature/const ref

### DIFF
--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -528,7 +528,7 @@ class StdPairConverter(TypeConverterBase):
             """, locals())
 
         cleanup_code = Code()
-        if cpp_type.is_ref:
+        if cpp_type.is_ref and not cpp_type.is_const:
             if not i1.is_enum and t1.base_type in self.converters.names_of_wrapper_classes:
                 temp1 = "temp1"
                 cleanup_code.add("""
@@ -693,7 +693,7 @@ class StdMapConverter(TypeConverterBase):
                 value_conv_cleanup = Code().add("")
                 value_conv_code = Code().add("$vtemp_var = $value_var", locals())
                 value_conv = "%s" % vtemp_var
-                if cpp_type.topmost_is_ref:
+                if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
                     cleanup_code = Code().add("""
                         |$value_var[:] = $vtemp_var
                         """, locals())
@@ -728,7 +728,7 @@ class StdMapConverter(TypeConverterBase):
         code.add(key_conv_cleanup)
         code.add(value_conv_cleanup)
 
-        if cpp_type.is_ref:
+        if cpp_type.is_ref and not cpp_type.is_const:
             it = mangle("it_" + argument_var)
 
             key_conv = "<%s> deref(%s).first" % (cy_tt_key, it)
@@ -885,7 +885,7 @@ class StdSetConverter(TypeConverterBase):
                 |for $item in $argument_var:
                 |   $temp_var.insert(<$inner> $item)
                 """, locals())
-            if cpp_type.is_ref:
+            if cpp_type.is_ref and not cpp_type.is_const:
                 cleanup_code = Code().add("""
                     |replace = set()
                     |cdef libcpp_set[$inner].iterator $it = $temp_var.begin()
@@ -917,7 +917,7 @@ class StdSetConverter(TypeConverterBase):
                 |for $item in $argument_var:
                 |   $temp_var.insert($do_deref($item.inst.get()))
                 """, locals())
-            if cpp_type.is_ref:
+            if cpp_type.is_ref and not cpp_type.is_const:
 
                 instantiation = self._codeForInstantiateObjectFromIter(inner, it)
                 cleanup_code = Code().add("""
@@ -944,7 +944,7 @@ class StdSetConverter(TypeConverterBase):
                 """, locals())
 
             cleanup_code = ""
-            if cpp_type.is_ref:
+            if cpp_type.is_ref and not cpp_type.is_const:
                 cleanup_code = Code().add("""
                     |$argument_var.clear()
                     |$argument_var.update($temp_var)
@@ -1025,7 +1025,7 @@ class StdVectorConverter(TypeConverterBase):
 
     def _prepare_nonrecursive_cleanup(self, cpp_type, bottommost_code, it_prev, temp_var, recursion_cnt, *a, **kw):
         # B) Prepare the post-call
-        if cpp_type.topmost_is_ref:
+        if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
             # If the vector is passed by reference, we need to store the
             # result for Python.
             btm_add = ""
@@ -1065,7 +1065,7 @@ class StdVectorConverter(TypeConverterBase):
 
     def _prepare_recursive_cleanup(self, cpp_type, bottommost_code, it_prev, temp_var, recursion_cnt, *a, **kw):
         # B) Prepare the post-call
-        if cpp_type.topmost_is_ref:
+        if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
             # If the vector is passed by reference, we need to store the
             # result for Python.
             if recursion_cnt > 0:
@@ -1091,7 +1091,7 @@ class StdVectorConverter(TypeConverterBase):
     def _prepare_nonrecursive_precall(self, topmost_code, cpp_type, code_top, do_deref, *a, **kw):
             # A) Prepare the pre-call
         if topmost_code is not None:
-            if cpp_type.topmost_is_ref:
+            if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
                     # add cdef statements for the iterators (part of B, post-call but needs to
                     # be on top)
                 code_top += "|cdef libcpp_vector[$inner].iterator $it"
@@ -1177,7 +1177,7 @@ class StdVectorConverter(TypeConverterBase):
         # append the result from the inner loop iteration to the current result
         # (only if we actually give back the reference)
         #
-        if cpp_type.topmost_is_ref:
+        if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
             cleanup_code.add("""
                 |    replace_$recursion_cnt.append(replace_$recursion_cnt_next)
                 |    inc($it)
@@ -1190,7 +1190,7 @@ class StdVectorConverter(TypeConverterBase):
         if bottommost_code is None:
             # we are the outermost loop
             cleanup_code.content.extend(bottommost_code_callback.content)
-            if cpp_type.topmost_is_ref:
+            if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
                 cleanup_code.add("""
                     |$argument_var[:] = replace_$recursion_cnt
                     |del $temp_var
@@ -1250,7 +1250,7 @@ class StdVectorConverter(TypeConverterBase):
                 |for $item in $argument_var:
                 |    $temp_var.push_back(<$inner> $item)
                 """, locals())
-            if cpp_type.topmost_is_ref:
+            if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
                 cleanup_code = Code().add("""
                     |replace = []
                     |cdef libcpp_vector[$inner].iterator $it = $temp_var.begin()
@@ -1308,7 +1308,7 @@ class StdVectorConverter(TypeConverterBase):
 
             cleanup_code = Code().add("")
 
-            if cpp_type.topmost_is_ref:
+            if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
                 item2 = "%s_rec_b" % argument_var
                 instantiation = self._codeForInstantiateObjectFromIter(inner, it)
                 cleanup_code = Code().add("""
@@ -1345,7 +1345,7 @@ class StdVectorConverter(TypeConverterBase):
             # A) Prepare the pre-call
             code = Code()
             if topmost_code is not None:
-                if cpp_type.topmost_is_ref:
+                if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
                     # add cdef statements for the iterators (part of B, post-call but needs to
                     # be on top)
                     code_top += "|cdef libcpp_vector[$inner].iterator $it"
@@ -1376,7 +1376,7 @@ class StdVectorConverter(TypeConverterBase):
                 """, locals())
 
             cleanup_code = Code().add("")
-            if cpp_type.topmost_is_ref:
+            if cpp_type.topmost_is_ref and not cpp_type.topmost_is_const:
                 cleanup_code = Code().add("""
                     |$argument_var[:] = $temp_var
                     """, locals())
@@ -1531,7 +1531,7 @@ class SharedPtrConverter(TypeConverterBase):
         call_as = "input_" + argument_var
         cleanup = ""
         # Put the pointer back if we pass by reference
-        if cpp_type.is_ref:
+        if cpp_type.is_ref and not cpp_type.is_const:
             cleanup = Code().add("""
                 |$argument_var.inst = input_$argument_var
                 """, locals())

--- a/autowrap/Types.py
+++ b/autowrap/Types.py
@@ -53,9 +53,20 @@ class CppType(object):
         self.enum_items = enum_items
         self.template_args = template_args and tuple(template_args)
         self.topmost_is_ref = False
+        self.topmost_is_const = False
         if self.is_ref:
             self.set_is_ref_rec()
             self.topmost_is_ref = True
+        if self.is_const:
+            self.set_is_const_rec()
+            self.topmost_is_const = True
+
+    def set_is_const_rec(self):
+        self.topmost_is_const = True
+        if self.template_args is None:
+            return
+        for t in self.template_args:
+            t.set_is_const_rec()
 
     def set_is_ref_rec(self):
         self.topmost_is_ref = True

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -719,6 +719,11 @@ def test_minimal():
     assert in_ == [m2, minimal]
 
     assert len(in_) == 2
+    assert m3.call3(in_) == 1
+    assert len(in_) == 2
+    assert in_ == [m2, minimal]
+
+    assert len(in_) == 2
     assert m3.call2(in_) == 1
     assert len(in_) == 3
     assert in_ == [m2, minimal, m2]

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -686,8 +686,31 @@ def test_minimal():
     m3 = wrapped.Minimal([1, 2, 3])
     assert m3.compute(0) == 4
 
+    ### Different ways of wrapping a function: 
+    # all three call() methods (call, call2, call3) do exactly the same thing
+    # and all modify the input argument. However, they are wrapped differently
+    # in the pxd file:
+    #
+    #   int call(libcpp_vector[Minimal] what) # ref-arg-out:0
+    #   int call2(libcpp_vector[Minimal]& what) # ref-arg-out:0
+    #   int call3(const libcpp_vector[Minimal]& what) # ref-arg-out:0
+    #
+    # and therefore only call2 will actually modify its input arguments (since
+    # call assumes call by value, call3 assumes call by const-ref and only
+    # call2 implements a full call by ref).
+    #
+    assert len(in_) == 2
+    assert m3.call(in_) == 1
+    assert len(in_) == 2
+    assert in_ == [m2, minimal]
+
+    assert len(in_) == 2
+    assert m3.call2(in_) == 1
+    assert len(in_) == 3
+    assert in_ == [m2, minimal, m2]
+
     in_ = [b"a", b"bc"]
-    assert m3.call2(in_) == 3
+    assert m3.call_str(in_) == 3
     assert in_ == [b"a", b"bc", b"hi"]
 
     msg, = m3.message()

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -666,6 +666,20 @@ def test_minimal():
     assert minimal.run(minimal) == 4
     assert minimal.run2(minimal) == 5
 
+    # Note that both C++ calls run3 and run4 do modify the object -- the fact
+    # that Cython thinks run4 is const does not impact this!
+    tm = wrapped.Minimal(5)
+    assert tm.get() == 5
+    assert tm.run3(tm) == 14
+    assert tm.get() == 10
+    assert tm.run3(tm) == 24
+    assert tm.get() == 20
+    tm = wrapped.Minimal(5)
+    assert tm.run4(tm) == 14
+    assert tm.get() == 10
+    assert tm.run4(tm) == 24
+    assert tm.get() == 20
+
     assert minimal.create().compute(3) == 4
 
     assert minimal.sumup([1, 2, 3]) == 6

--- a/tests/test_files/minimal.cpp
+++ b/tests/test_files/minimal.cpp
@@ -76,6 +76,16 @@ int Minimal::run2(Minimal * inst) const
 {
     return inst->compute_int(4);
 }
+int Minimal::run3(Minimal &ref) const
+{
+    ref += ref; 
+    return ref.compute_int(3);
+}
+int Minimal::run4(Minimal &ref) const
+{
+    ref += ref; 
+    return ref.compute_int(3);
+}
 
 Minimal Minimal::create() const
 {

--- a/tests/test_files/minimal.cpp
+++ b/tests/test_files/minimal.cpp
@@ -88,7 +88,7 @@ Minimal & Minimal::getRef()
     return *this;
 }
 
-int Minimal::sumup(std::vector<int> & what) const {
+int Minimal::sumup(const std::vector<int> & what) const {
     int sum = 0;
     for (std::vector<int>::const_iterator it = what.begin(); it != what.end(); ++it)
         sum += *it;
@@ -104,7 +104,29 @@ int Minimal::call(std::vector<Minimal> & arg) const
     return sum;
 }
 
-int Minimal::call2(std::vector<std::string> & arg) const
+int Minimal::call2(std::vector<Minimal> & arg) const
+{
+    int sum = 0;
+    for (std::vector<Minimal>::const_iterator it = arg.begin(); it != arg.end(); ++it)
+        sum += it->compute(0);
+
+    arg.push_back(arg.at(0));
+    return sum;
+}
+
+
+int Minimal::call3(std::vector<Minimal> & arg) const
+{
+    int sum = 0;
+    for (std::vector<Minimal>::const_iterator it = arg.begin(); it != arg.end(); ++it)
+        sum += it->compute(0);
+
+    arg.push_back(arg.at(0));
+    return sum;
+}
+
+
+int Minimal::call_str(std::vector<std::string> & arg) const
 {
     int sum = 0;
     for (std::vector<std::string>::const_iterator it = arg.begin(); it != arg.end(); ++it)

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -40,6 +40,8 @@ class Minimal {
         int compute_charp(char *p) const;
         int run(const Minimal &) const;
         int run2(Minimal *) const;
+        int run3(Minimal &) const;
+        int run4(Minimal &) const;
 
         unsigned int test_special_converter(unsigned int l) const;
 
@@ -106,3 +108,4 @@ class Minimal {
 
 int top_function(int i);
 int sumup(std::vector<int> &);
+

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -43,9 +43,11 @@ class Minimal {
 
         unsigned int test_special_converter(unsigned int l) const;
 
-        int sumup(std::vector<int> &) const;
+        int sumup(const std::vector<int> &) const;
         int call(std::vector<Minimal> & arg) const;
-        int call2(std::vector<std::string> & arg) const;
+        int call2(std::vector<Minimal> & arg) const;
+        int call3(std::vector<Minimal> & arg) const;
+        int call_str(std::vector<std::string> & arg) const;
 
         bool operator==(const Minimal &other) const;
 

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -45,7 +45,7 @@ cdef extern from "minimal.hpp":
         void setVector(libcpp_vector[Minimal])
         libcpp_vector[Minimal] getVector()
 
-        int test2Lists(libcpp_vector[Minimal], libcpp_vector[int])
+        int test2Lists(const libcpp_vector[Minimal]&, libcpp_vector[int])
 
         libcpp_vector[Minimal].iterator begin() # wrap-iter-begin:__iter__(Minimal)
         libcpp_vector[Minimal].iterator end()   # wrap-iter-end:__iter__(Minimal)

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -34,8 +34,12 @@ cdef extern from "minimal.hpp":
         const_char * pass_const_charptr(const_char *)
         libcpp_string compute_str(libcpp_string what)
         int compute_charp(char * what)
+        # Note how both run3 and run4 have the same implementation - declaring
+        # it const in Cython will not affect the result!
         int run(Minimal & ref)
         int run2(Minimal *p)
+        int run3(Minimal & ref)
+        int run4(const Minimal & ref) # attention here!
         Minimal create()
         Minimal & getRef()   # wrap-ignore
 
@@ -55,6 +59,9 @@ cdef extern from "minimal.hpp":
         int size()
         int operator[](size_t index) #wrap-upper-limit:size()
 
+        # Note how both call, call2 and call3 have the same implementation -
+        # however, declaring it const in Cython will affect the result since it
+        # will not get copied back!
         int sumup(libcpp_vector[int]& what)
         int call(libcpp_vector[Minimal] what) # ref-arg-out:0
         int call2(libcpp_vector[Minimal]& what) # ref-arg-out:0

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -55,9 +55,11 @@ cdef extern from "minimal.hpp":
         int size()
         int operator[](size_t index) #wrap-upper-limit:size()
 
-        int sumup(libcpp_vector[int] what)
+        int sumup(libcpp_vector[int]& what)
         int call(libcpp_vector[Minimal] what) # ref-arg-out:0
-        int call2(libcpp_vector[libcpp_string] & what)
+        int call2(libcpp_vector[Minimal]& what) # ref-arg-out:0
+        int call3(const libcpp_vector[Minimal]& what) # ref-arg-out:0
+        int call_str(libcpp_vector[libcpp_string] & what)
         libcpp_vector[libcpp_string] message()
         libcpp_vector[Minimal] create_two()
         int operator==(Minimal &)


### PR DESCRIPTION
I am wondering how to best implement `const X &` function arguments. In principle that is an important convention used in C++ in order to provide efficient call by references while promising not to modify the object. If autowrap knows about this, then there is no need to copy back all the data in call where no data has been modified. 

This PR adds awareness for const arguments and does not copy back any data in case of const arguments. This makes it easier to express in Cython what the C++ code really wants and makes the wrapper more efficient. It also fixes an issue with const templates: since const-ness was computed after looking at templates, we would get type resolutions to type `void` and the following would fail:

```
int call2(const libcpp_vector[libcpp_string] & what)
```

with `    raise NotImplementedError("void has no matching python type")`.

However, there is a price to pay: autowrap has to assume that the user correctly specified the function (e.g. if C++ is non-const and modifies the object, autowrap will omit the copy-back operation which leads to surprises). On the other hand, its the users responsibility to provide correct input but we simply cannot check const-correctness. The only way I currently see us doing this would be for the const-arguments to replace all calls of 

```
self.inst.get().run((deref(inp.inst.get())))
```

with 

```
cdef const XType_ * tmp_ptr = inp.inst.get()
self.inst.get().run((deref( tmp_ptr )))
```

which would do automated checks. It would be with no overhead (I think) since its a compile-time check that gets optimized away at runtime, but its extra work for us. 