### PR TITLE
Introducing libcpp_utf8_output_string type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ pip-log.txt
 tests/test_files/gil_testing_wrapper.pyx
 tests/test_files/libcpp_stl_test.pyx
 tests/test_files/libcpp_utf8_string_test.pyx
+tests/test_files/libcpp_utf8_output_string_test.pyx
 tests/test_files/number_conv.pyx
 

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1203,6 +1203,7 @@ class CodeGenerator(object):
                    |#cython: embedsignature=False
                    |from  libcpp.string  cimport string as libcpp_string
                    |from  libcpp.string  cimport string as libcpp_utf8_string
+                   |from  libcpp.string  cimport string as libcpp_utf8_output_string
                    |from  libcpp.set     cimport set as libcpp_set
                    |from  libcpp.vector  cimport vector as libcpp_vector
                    |from  libcpp.pair    cimport pair as libcpp_pair

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -1501,6 +1501,15 @@ class StdStringUnicodeConverter(StdStringConverter):
         return "isinstance(%s, (bytes, unicode))" % argument_var
 
 
+class StdStringUnicodeOutputConverter(StdStringUnicodeConverter):
+
+    def get_base_types(self):
+        return "libcpp_utf8_output_string",
+
+    def output_conversion(self, cpp_type, input_cpp_var, output_py_var):
+        return "%s = %s.decode('utf-8')" % (output_py_var, input_cpp_var)
+
+
 class SharedPtrConverter(TypeConverterBase):
 
     """
@@ -1584,6 +1593,7 @@ def setup_converter_registry(classes_to_wrap, enums_to_wrap, instance_map):
     converters.register(CharConverter())
     converters.register(StdStringConverter())
     converters.register(StdStringUnicodeConverter())
+    converters.register(StdStringUnicodeOutputConverter())
     converters.register(StdVectorConverter())
     converters.register(StdSetConverter())
     converters.register(StdMapConverter())

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -43,6 +43,7 @@ import autowrap
 import os
 import math
 import copy
+import sys
 
 from .utils import expect_exception
 
@@ -884,6 +885,32 @@ def test_automatic_string_conversion():
 
     msg = h.get_more({"greet": input_greet_unicode, "name": input_bytes})
     assert isinstance(msg, bytes)
+    assert msg == expected
+
+
+def test_automatic_output_string_conversion():
+    target = os.path.join(test_files, "libcpp_utf8_output_string_test.pyx")
+    include_dirs = autowrap.parse_and_generate_code(["libcpp_utf8_output_string_test.pxd"],
+                                                    root=test_files, target=target, debug=True)
+
+    wrapped = autowrap.Utils.compile_and_import("libcpp_utf8_output_string_wrapped", [target, ],
+                                                include_dirs)
+    h = wrapped.LibCppUtf8OutputStringTest()
+
+    input_bytes = b"J\xc3\xbcrgen"
+    input_unicode = b"J\xc3\xbcrgen".decode('utf-8')
+
+    expected = b"Hello J\xc3\xbcrgen".decode('utf-8')
+    expected_type = str
+    if sys.version_info[0] < 3:
+        expected_type = unicode
+
+    msg = h.get(input_bytes)
+    assert isinstance(msg, expected_type)
+    assert msg == expected
+
+    msg = h.get(input_unicode)
+    assert isinstance(msg, expected_type)
     assert msg == expected
 
 

--- a/tests/test_files/libcpp_utf8_output_string_test.hpp
+++ b/tests/test_files/libcpp_utf8_output_string_test.hpp
@@ -1,0 +1,14 @@
+#include <string>
+#include <sstream>
+#include <map>
+
+
+class LibCppUtf8OutputStringTest {
+    public:
+        LibCppUtf8OutputStringTest(){}
+
+        std::string get(const std::string& s) const {
+            std::string msg = "Hello " + s;
+            return msg;
+        }
+};

--- a/tests/test_files/libcpp_utf8_output_string_test.pxd
+++ b/tests/test_files/libcpp_utf8_output_string_test.pxd
@@ -1,0 +1,6 @@
+from libcpp.string cimport string as libcpp_utf8_output_string
+
+cdef extern from "libcpp_utf8_output_string_test.hpp":
+    cdef cppclass LibCppUtf8OutputStringTest:
+        LibCppUtf8OutputStringTest()
+        libcpp_utf8_output_string get(libcpp_utf8_output_string)


### PR DESCRIPTION
This PR introduces `libcpp_utf8_output_string` type, which decodes bytes to strings/unicodes  on function return.

This was initially implemented for https://github.com/KeyviDev/keyvi project as currently both `libcpp_string` and `libcpp_utf8_string` types are converted to `bytes` on function return.