### PR TITLE
Static wrapas

### DIFF
--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -764,6 +764,7 @@ def test_minimal():
     assert wrapped.top_function(42) == 84
     assert wrapped.sumup([1, 2, 3]) == 6
     assert wrapped.Minimal.run_static(1) == 4
+    assert wrapped.Minimal.run_static_extra_arg(1, True) == 4
 
     # != not declared, so:
     expect_exception(lambda m1, m2: m1 != m2)(m1, m2)

--- a/tests/test_decl_resolver.py
+++ b/tests/test_decl_resolver.py
@@ -143,7 +143,7 @@ def _resolve(*names, **kwargs):
 
 
 def test_simple():
-    (cdcl, enumdcl, f1, f2, f3), map_ = _resolve("minimal.pxd", num_processes=1)
+    (cdcl, enumdcl, f1, f2, f3, f4), map_ = _resolve("minimal.pxd", num_processes=1)
 
     assert cdcl.name == "Minimal"
     assert enumdcl.name == "ABCorD"
@@ -152,9 +152,12 @@ def test_simple():
     assert f1.name == "top_function"
     assert f2.name == "sumup"
     assert f3.name == "run_static"
+    assert f3.name == f3.cpp_decl.name
+    assert f4.name == "run_static_extra_arg"
+    assert f4.cpp_decl.name == "run_static" # need to remember the raw cpp fxn name
 
 def test_simple_mp():
-    (cdcl, enumdcl, f1, f2, f3), map_ = _resolve("minimal.pxd", num_processes=2)
+    (cdcl, enumdcl, f1, f2, f3, f4), map_ = _resolve("minimal.pxd", num_processes=2)
 
     assert cdcl.name == "Minimal"
     assert enumdcl.name == "ABCorD"

--- a/tests/test_files/minimal.cpp
+++ b/tests/test_files/minimal.cpp
@@ -195,7 +195,7 @@ std::vector<Minimal>::iterator Minimal::end()
     return this->_mi.end();
 }
 
-long int Minimal::run_static(long int i)
+long int Minimal::run_static(long int i, bool)
 {
     return i*4;
 }

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -79,7 +79,7 @@ class Minimal {
 
         enum ABCorD enumTest(enum ABCorD) const;
 
-        static long int run_static(long int);
+        static long int run_static(long int, bool = true);
 
         operator int() const {
             return 4711;

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -84,3 +84,5 @@ cdef extern from "minimal.hpp" namespace "Minimal":
 
     long int run_static(long int) # wrap-attach:Minimal
 
+    long int run_static(long int, bool) # wrap-attach:Minimal wrap-as:run_static_extra_arg
+


### PR DESCRIPTION
enables `wrap-as` also for static functions

```
 cdef extern from "minimal.hpp" namespace "Minimal":
 
     long int run_static(long int) # wrap-attach:Minimal
 
     long int run_static(long int, bool) # wrap-attach:Minimal wrap-as:run_static_extra_arg

```

please merge and create new autowrap version