### PR TITLE
Feature/enum mapping

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -110,6 +110,10 @@ class CodeGenerator(object):
         self.target_path = os.path.abspath(pyx_target_path)
         self.target_pxd_path = self.target_path.split(".pyx")[0] + ".pxd"
         self.target_dir = os.path.dirname(self.target_path)
+
+        # If true, we will write separate pxd and pyx files (need to ensure the
+        # right code goes to header if we use pxd headers). Alternatively, we
+        # will simply write a single pyx file.
         self.write_pxd = len(allDecl) > 0
 
         ## Step 1: get all classes of current module
@@ -306,6 +310,7 @@ class CodeGenerator(object):
         L.info("create wrapper for enum %s" % name)
         code = Code.Code()
         enum_pxd_code = Code.Code()
+
         enum_pxd_code.add("""
                    |
                    |cdef class $name:
@@ -320,11 +325,9 @@ class CodeGenerator(object):
 
         # Add mapping of int (enum) to the value of the enum (as string)
         code.add("""
-                |    cdef dict __enum_mapping
-                |    def __init__(self):
-                |        self.__enum_mapping = dict([ (v, k) for k, v in self.__class__.__dict__.items() if isinstance(v, int) ])
+                |
                 |    def getMapping(self):
-                |        return self.__enum_mapping""")
+                |        return dict([ (v, k) for k, v in self.__class__.__dict__.items() if isinstance(v, int) ])""" )
 
         self.class_codes[decl.name] = code
         self.class_pxd_codes[decl.name] = enum_pxd_code

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -317,6 +317,15 @@ class CodeGenerator(object):
                  """, name=name)
         for (name, value) in decl.items:
             code.add("    $name = $value", name=name, value=value)
+
+        # Add mapping of int (enum) to the value of the enum (as string)
+        code.add("""
+                |    cdef dict __enum_mapping
+                |    def __init__(self):
+                |        self.__enum_mapping = dict([ (v, k) for k, v in self.__class__.__dict__.iteritems() if isinstance(v, int) ])
+                |    def getMapping(self):
+                |        return self.__enum_mapping""")
+
         self.class_codes[decl.name] = code
         self.class_pxd_codes[decl.name] = enum_pxd_code
 

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -322,7 +322,7 @@ class CodeGenerator(object):
         code.add("""
                 |    cdef dict __enum_mapping
                 |    def __init__(self):
-                |        self.__enum_mapping = dict([ (v, k) for k, v in self.__class__.__dict__.iteritems() if isinstance(v, int) ])
+                |        self.__enum_mapping = dict([ (v, k) for k, v in self.__class__.__dict__.items() if isinstance(v, int) ])
                 |    def getMapping(self):
                 |        return self.__enum_mapping""")
 

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 19, 0)
+__version__ = (0, 19, 1)
 
 # for compatibility with older version:
 version = __version__

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 from setuptools import find_packages, setup
 
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
-VERSION = (0, 19, 0)
+VERSION = (0, 19, 1)
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
 
 

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -631,6 +631,12 @@ def test_minimal():
 
     minimal = wrapped.Minimal()
 
+    assert len(wrapped.Minimal.ABCorD().getMapping()) == 4
+    assert wrapped.Minimal.ABCorD().getMapping()[0] == 'A'
+    assert wrapped.Minimal.ABCorD().getMapping()[2] == 'B'
+    assert wrapped.Minimal.ABCorD().getMapping()[3] == 'C'
+    assert wrapped.Minimal.ABCorD().getMapping()[4] == 'D'
+
     assert len(minimal.compute.__doc__) == 297
 
     # test members


### PR DESCRIPTION
add a `getMapping()` function for enums to actual be able to convert the integers to a human-readable result:

```
>>> wrapped.Minimal.ABCorD().getMapping()
{0: 'A', 2: 'B', 3: 'C', 4: 'D'}
```