### PR TITLE
[Fix] fix definition of python version that breaks openMS build with py3

### DIFF
--- a/autowrap/Main.py
+++ b/autowrap/Main.py
@@ -184,7 +184,7 @@ def run_cython(inc_dirs, extra_opts, out):
 
     directive_defaults["boundscheck"] = False
     directive_defaults["wraparound"] = False
-    directive_defaults["language_level"] = sys.version_info.major
+    #directive_defaults["language_level"] = sys.version_info.major
     options = dict(include_path=inc_dirs,
                    compiler_directives=directive_defaults,
                    cplus=True)


### PR DESCRIPTION
This fixes a the specification of python version which breaks the OpenMS build.