### PR TITLE
[DOCU] attempt to allow more powerful docstrings for classes

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -47,6 +47,10 @@ import autowrap.Code as Code
 
 import logging as L
 
+special_class_doc = ""
+def namespace_handler(ns):
+    return ns
+
 try:
     unicode = unicode
 except NameError:
@@ -356,11 +360,19 @@ class CodeGenerator(object):
 
         L.info("create wrapper for class %s" % cname)
         cy_type = self.cr.cython_type(cname)
+
+        # Attempt to derive sane class name and namespace
+        cpp_name = str(cy_type)
+        namespace = namespace_handler(r_class.ns)
+        if cpp_name.startswith("_"):
+            cpp_name = cpp_name[1:]
+
         class_pxd_code = Code.Code()
         class_code = Code.Code()
 
         # Class documentation (multi-line)
         docstring = "Cython implementation of %s\n" % cy_type
+        docstring += special_class_doc % locals()
         if r_class.cpp_decl.annotations.get("wrap-inherits", "") != "":
             docstring += "     -- Inherits from %s\n" % r_class.cpp_decl.annotations.get("wrap-inherits", "")
 

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -144,6 +144,19 @@ class ResolvedAttribute(object):
         self.wrap_ignore = decl.annotations.get("wrap-ignore", False)
 
 
+default_namespace = ""
+
+def get_namespace(pxd, default_namespace):
+    filehandle = open(pxd)
+    fulltext = filehandle.read()
+    filehandle.close()
+    import re
+    match = re.search("cdef extern.*?namespace\s*\"([^\"]*)\"", fulltext)
+    if not match:
+        return default_namespace
+    else:
+        return match.group(1)
+
 class ResolvedClass(object):
 
     """ contains all info for generating wrapping code of
@@ -160,7 +173,8 @@ class ResolvedClass(object):
         self.attributes = attributes
 
         self.cpp_decl = decl
-        # self.items = getattr(decl, "items", [])
+        self.ns = get_namespace(decl.pxd_path, default_namespace)
+
         self.wrap_ignore = decl.annotations.get("wrap-ignore", False)
         self.no_pxd_import = decl.annotations.get("no-pxd-import", False)
         self.wrap_manual_memory = decl.annotations.get("wrap-manual-memory", [])


### PR DESCRIPTION
will allow a user to inject more powerful documentation directly into the Cython class docu. 

We would like to use this to generate links to the C++ API docu through

```
classdocu_base = "http://www.openms.de/current_doxygen/html/"
autowrap.CodeGenerator.special_class_doc = "\n    Documentation is available at " + 
  classdocu_base + "class%(namespace)s_1_1%(cpp_name)s.html\n\n"
```