### PR TITLE
Feature/ref return values

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -601,8 +601,9 @@ class CodeGenerator(object):
                 return codes
             elif op == "[]":
                 assert len(methods) == 1, "overloaded operator[] not suppored"
-                code = self.create_special_getitem_method(methods[0])
-                return [code]
+                code_get = self.create_special_getitem_method(methods[0])
+                code_set = self.create_special_setitem_method(methods[0])
+                return [code_get, code_set]
             elif op == "+":
                 assert len(methods) == 1, "overloaded operator+ not suppored"
                 code = self.create_special_add_method(cdcl, methods[0])
@@ -648,8 +649,7 @@ class CodeGenerator(object):
         args = augment_arg_names(method)
 
         # Step 0: collect conversion data for input args and call
-        # input_conversion for more sophisticated conversion code (e.g.
-        # std::vector<Obj>)
+        # input_conversion for more sophisticated conversion code (e.g. std::vector<Obj>)
         py_signature_parts = []
         input_conversion_codes = []
         cleanups = []
@@ -1041,7 +1041,7 @@ class CodeGenerator(object):
         return code
 
     def create_special_getitem_method(self, mdcl):
-        L.info("   create wrapper for operator[]")
+        L.info("   create get wrapper for operator[]")
         meth_code = Code.Code()
 
         (call_arg,), cleanups, (in_type,) =\
@@ -1094,6 +1094,52 @@ class CodeGenerator(object):
                 to_py_code = "    %s" % to_py_code
             meth_code.add(to_py_code)
             meth_code.add("    return $out_var", locals())
+
+        return meth_code
+
+    def create_special_setitem_method(self, mdcl):
+        # Note: setting will only work with a ref signature
+        #   Object operator[](size_t k)  -> only get is implemented
+        #   Object& operator[](size_t k) -> get and set is implemented
+        res_t = mdcl.result_type
+        if not res_t.is_ref:
+            L.info("   skip set wrapper for operator[] since return value is not a reference")
+            return Code.Code()
+
+        res_t_base = res_t.base_type
+
+        L.info("   create set wrapper for operator[]")
+        meth_code = Code.Code()
+
+        call_arg = "key"
+        value_arg = "value"
+
+        meth_code.add("""
+                     |def __setitem__(self, key, $res_t_base value):
+                     |    \"\"\"Test\"\"\"
+                     |    assert isinstance(key, (int, long)), 'arg index wrong type'
+                     |
+                     |    cdef long _idx = $call_arg
+                     |    if _idx < 0:
+                     |        raise IndexError("invalid index %d" % _idx)
+                     """, locals())
+
+        size_guard = mdcl.cpp_decl.annotations.get("wrap-upper-limit")
+        if size_guard:
+            meth_code.add("""
+                     |    if _idx >= self.inst.get().$size_guard:
+                     |        raise IndexError("invalid index %d" % _idx)
+                     """, locals())
+
+        # Store the input argument as
+        #  CppObject[ idx ] = value
+        #
+        cy_call_str = "deref(self.inst.get())[%s]" % call_arg
+        out_converter = self.cr.get(res_t)
+        code, call_as, cleanup = out_converter.input_conversion(res_t, value_arg, 0)
+        meth_code.add("""
+                 |    $cy_call_str = $call_as
+                 """, locals())
 
         return meth_code
 

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -157,7 +157,14 @@ class TypeConverterBase(object):
         """
         Creates a temporary object which has the type of the current TypeConverter object.
 
-        The object is *always* named "_r" and will be of type "res_type". It will be assigned the value of "cy_call_str".
+        The object is *always* named "_r" and will be of type "res_type". It
+        will be assigned the value of "cy_call_str".
+
+        Note that Cython cannot declare C++ references, therefore 
+
+           cdef int & _r 
+
+        Is illegal to declare and we have to remove any references from the type.
         """
         cy_res_type = self.converters.cython_type(res_type)
         if cy_res_type.is_ref:
@@ -485,9 +492,9 @@ class TypeToWrapConverter(TypeConverterBase):
     def output_conversion(self, cpp_type, input_cpp_var, output_py_var):
 
         cy_clz = self.converters.cython_type(cpp_type)
-        if cpp_type.is_ptr:
-            cy_clz = cy_clz.base_type
-        if cpp_type.is_ref:
+
+        # Need to ensure that type inside the raw ptr is an object and not a ref/ptr
+        if cpp_type.is_ptr or cpp_type.is_ref:
             cy_clz = cy_clz.base_type
 
         t = cpp_type.base_type

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -154,7 +154,16 @@ class TypeConverterBase(object):
         raise NotImplementedError()
 
     def call_method(self, res_type, cy_call_str):
+        """
+        Creates a temporary object which has the type of the current TypeConverter object.
+
+        The object is *always* named "_r" and will be of type "res_type". It will be assigned the value of "cy_call_str".
+        """
         cy_res_type = self.converters.cython_type(res_type)
+        if cy_res_type.is_ref:
+            cy_res_type = cy_res_type.base_type
+            return "cdef %s _r = %s" % (cy_res_type, cy_call_str)
+
         return "cdef %s _r = %s" % (cy_res_type, cy_call_str)
 
     def matching_python_type(self, cpp_type):
@@ -164,6 +173,14 @@ class TypeConverterBase(object):
         raise NotImplementedError()
 
     def input_conversion(self, cpp_type, argument_var, arg_num):
+        """
+        Sets up the conversion of input arguments.
+
+        Returns a tuple as follows:
+          - code : a code object to be added to the beginning of the function
+          - call_as : a piece of code indicating how the argument should be called as going forward
+          - cleanup : a piece of cleanup code to be added to the bottom of the function
+        """
         raise NotImplementedError()
 
     def output_conversion(self, cpp_type, input_cpp_var, output_py_var):
@@ -182,6 +199,9 @@ class TypeConverterBase(object):
             shared_ptr[ _FooObject ] (new _FooObject (*foo_iter)  )
             shared_ptr[ _FooObject ] (new _FooObject (**foo_iter_ptr)  )
         """
+
+        if cpp_type.is_ref:
+            cpp_type = cpp_type.base_type
 
         if cpp_type.is_ptr:
             cpp_type_base = cpp_type.base_type
@@ -241,6 +261,9 @@ class IntegerConverter(TypeConverterBase):
 
     def input_conversion(self, cpp_type, argument_var, arg_num):
         code = ""
+        if cpp_type.is_ref:
+            cpp_type = cpp_type.base_type
+
         call_as = "(<%s>%s)" % (cpp_type, argument_var)
         cleanup = ""
         return code, call_as, cleanup
@@ -433,13 +456,17 @@ class TypeToWrapConverter(TypeConverterBase):
             call_as = "(%s.inst.get())" % (argument_var, )
         else:
             call_as = "(deref(%s.inst.get()))" % (argument_var, )
+
         cleanup = ""
         return code, call_as, cleanup
 
     def call_method(self, res_type, cy_call_str):
         t = self.converters.cython_type(res_type)
 
-        if t.is_ptr:
+        if t.is_ref:
+            # If t is a ref, we would like to call on the base type
+            t = t.base_type
+        elif t.is_ptr:
 
             # Special treatment for const raw ptr
             const = ""
@@ -462,6 +489,8 @@ class TypeToWrapConverter(TypeConverterBase):
 
         cy_clz = self.converters.cython_type(cpp_type)
         if cpp_type.is_ptr:
+            cy_clz = cy_clz.base_type
+        if cpp_type.is_ref:
             cy_clz = cy_clz.base_type
 
         t = cpp_type.base_type

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -261,9 +261,6 @@ class IntegerConverter(TypeConverterBase):
 
     def input_conversion(self, cpp_type, argument_var, arg_num):
         code = ""
-        if cpp_type.is_ref:
-            cpp_type = cpp_type.base_type
-
         call_as = "(<%s>%s)" % (cpp_type, argument_var)
         cleanup = ""
         return code, call_as, cleanup

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 21, 0)
+__version__ = (0, 22, 0)
 
 # for compatibility with older version:
 version = __version__

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 from setuptools import find_packages, setup
 
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
-VERSION = (0, 21, 0)
+VERSION = (0, 22, 0)
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
 
 

--- a/tests/test_code_generator_stllibcpp.py
+++ b/tests/test_code_generator_stllibcpp.py
@@ -74,6 +74,20 @@ def test_stl_libcpp():
     assert len(m1.map_) == 1
     assert len(m2.map_) == 2
 
+    # Test wrapping of operator[]
+    vec_wrapper = libcpp_stl.IntVecWrapper()
+    vec_wrapper.push_back(5)
+    assert vec_wrapper[0] == 5
+    vec_wrapper[0] = 7
+    assert vec_wrapper[0] == 7
+
+    vec_wrapper = libcpp_stl.LibCppSTLVector()
+    itest = libcpp_stl.IntWrapper(5)
+    vec_wrapper.push_back( itest )
+    assert vec_wrapper[0].i_ == 5
+    itest = libcpp_stl.IntWrapper(7)
+    vec_wrapper[0] = itest
+    assert vec_wrapper[0].i_ == 7
 
     # Part 1
     # Test std::set< Widget* >

--- a/tests/test_files/libcpp_stl_test.hpp
+++ b/tests/test_files/libcpp_stl_test.hpp
@@ -24,6 +24,24 @@ class IntWrapper {
         }
 };
 
+class IntVecWrapper {
+
+    public:
+      std::vector<int> iv_;
+
+        IntVecWrapper() {}
+
+        int& operator[](int i)
+        {
+          return iv_[i];
+        }
+
+        void push_back(int i)
+        {
+          iv_.push_back(i);
+        }
+};
+
 class MapWrapper {
 
     public:
@@ -34,6 +52,25 @@ class MapWrapper {
       {
         map_ = other.map_;
       }
+};
+
+class LibCppSTLVector
+{
+    std::vector<IntWrapper> m_list;
+    public:
+        LibCppSTLVector() {};
+
+        IntWrapper& operator[](int i)
+        {
+          return m_list[i];
+        }
+
+        size_t size() {return m_list.size();}
+
+        void push_back(const IntWrapper& i)
+        {
+          m_list.push_back(i);
+        }
 };
 
 class LibCppSTLTest {

--- a/tests/test_files/libcpp_stl_test.pxd
+++ b/tests/test_files/libcpp_stl_test.pxd
@@ -13,10 +13,24 @@ cdef extern from "libcpp_stl_test.hpp":
         IntWrapper(IntWrapper&)
         IntWrapper(int i)
 
+    cdef cppclass IntVecWrapper:
+        IntVecWrapper()
+        libcpp_vector[int] iv_
+
+        int& operator[](size_t index)
+        void push_back(int)
+
     cdef cppclass MapWrapper:
         libcpp_map[int, double] map_
         MapWrapper()
         MapWrapper(MapWrapper&)
+
+    cdef cppclass LibCppSTLVector:
+
+        LibCppSTLVector()
+        size_t size()
+        IntWrapper& operator[](size_t index) #wrap-upper-limit:size()
+        void push_back(const IntWrapper&)
 
     cdef cppclass LibCppSTLTest:
 

--- a/tests/test_files/minimal.cpp
+++ b/tests/test_files/minimal.cpp
@@ -135,6 +135,11 @@ int Minimal::call3(std::vector<Minimal> & arg) const
     return sum;
 }
 
+int Minimal::call4(int & arg) const
+{
+  arg += 1;
+  return arg;
+}
 
 int Minimal::call_str(std::vector<std::string> & arg) const
 {

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -49,6 +49,7 @@ class Minimal {
         int call(std::vector<Minimal> & arg) const;
         int call2(std::vector<Minimal> & arg) const;
         int call3(std::vector<Minimal> & arg) const;
+        int call4(int & arg) const;
         int call_str(std::vector<std::string> & arg) const;
 
         bool operator==(const Minimal &other) const;

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -67,6 +67,7 @@ cdef extern from "minimal.hpp":
         int call(libcpp_vector[Minimal] what) # ref-arg-out:0
         int call2(libcpp_vector[Minimal]& what) # ref-arg-out:0
         int call3(const libcpp_vector[Minimal]& what) # ref-arg-out:0
+        int call4(int & what)
         int call_str(libcpp_vector[libcpp_string] & what)
         libcpp_vector[libcpp_string] message()
         libcpp_vector[Minimal] create_two()


### PR DESCRIPTION
- correctly handle reference arguments and return values
- automatically produce `__setitem__` code for `operator[]` when return value is a ref


Automatically produces setitem/getitem code for `int& operator[](size_t index)`