### PR TITLE
[Feature] Preserve shared_ptrs for non-const-ref std::vector conversion

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1340,11 +1340,11 @@ class CodeGenerator(object):
                    """)
         if self.include_shared_ptr == "boost":
             code.add("""
-                   |from  smart_ptr cimport shared_ptr
+                   |from  smart_ptr cimport shared_ptr, make_shared
                    """)
         elif self.include_shared_ptr == "std":
             code.add("""
-                   |from libcpp.memory cimport shared_ptr
+                   |from libcpp.memory cimport shared_ptr, make_shared
                    """)
         if self.include_numpy:
             code.add("""

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -217,13 +217,13 @@ class TypeConverterBase(object):
 
     def _codeForMakeSharedPtrFromIter(self, cpp_type, it):
         """
-        Code for new object instantation from iterator (double deref for iterator-ptr)
+        Code for creation of a shared_ptr from the same memory location as the iterator (double deref for iterator-ptr)
         Note that if cpp_type is a pointer and the iterator therefore refers to
         a STL object of std::vector< _FooObject* >, then we need the base type
         to instantate a new object and dereference twice.
         Example output:
-            shared_ptr[ _FooObject ] (new _FooObject (*foo_iter)  )
-            shared_ptr[ _FooObject ] (new _FooObject (**foo_iter_ptr)  )
+            make_shared[ _FooObject ] (*foo_iter)
+            make_shared[ _FooObject ] (**foo_iter_ptr)
         """
 
         if cpp_type.is_ref:

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -235,9 +235,9 @@ class TypeConverterBase(object):
         else:
             return string.Template("make_shared[$cpp_type](deref($it))").substitute(locals())
 
-    def _codeForAddressFromIter(self, cpp_type, it):
+    def _codeForDerefFromIter(self, cpp_type, it):
         """
-        Code for creation of a shared_ptr from the same memory location as the iterator (double deref for iterator-ptr)
+        Code for creation of correct dereferencing code from an iterator (i.e. double deref for iterator-ptr)
         Note that if cpp_type is a pointer and the iterator therefore refers to
         a STL object of std::vector< _FooObject* >, then we need the base type
         to instantate a new object and dereference twice.
@@ -256,15 +256,11 @@ class TypeConverterBase(object):
         else:
             return string.Template("deref($it)").substitute(locals())
 
-    def _codeForPtrType(self, cpp_type, it):
+    def _codeForPtrType(self, cpp_type):
         """
-        Code for creation of a shared_ptr from the same memory location as the iterator (double deref for iterator-ptr)
-        Note that if cpp_type is a pointer and the iterator therefore refers to
-        a STL object of std::vector< _FooObject* >, then we need the base type
-        to instantate a new object and dereference twice.
+        Code for creation of a pointer type from the inner type
         Example output:
-            *foo_iter
-            **foo_iter_ptr
+            foo *
         """
 
         tmp_cpp_type = cpp_type
@@ -1387,8 +1383,8 @@ class StdVectorConverter(TypeConverterBase):
 
             instantiation = self._codeForInstantiateObjectFromIter(inner, it)
             make_shared = self._codeForMakeSharedPtrFromIter(inner, it)
-            address = self._codeForAddressFromIter(inner, it)
-            ptrtype = self._codeForPtrType(inner, it)
+            address = self._codeForDerefFromIter(inner, it)
+            ptrtype = self._codeForPtrType(inner)
             code = self._prepare_nonrecursive_precall(topmost_code, cpp_type, code_top, do_deref, locals())
             cleanup_code = self._prepare_nonrecursive_cleanup(
                 cpp_type, bottommost_code, it_prev, temp_var, recursion_cnt, locals())

--- a/autowrap/data_files/autowrap/smart_ptr.pxd
+++ b/autowrap/data_files/autowrap/smart_ptr.pxd
@@ -4,7 +4,11 @@ cdef extern from "boost/smart_ptr/shared_ptr.hpp" namespace "boost":
     cdef cppclass shared_ptr[T]:
         shared_ptr()
         shared_ptr(T*)
+        void swap(shared_ptr&)
         void reset()
         T* get() nogil
         int unique()
         int use_count()
+
+cdef extern from "boost/smart_ptr/make_shared.hpp" namespace "boost":
+    shared_ptr[T] make_shared[T](...) except +


### PR DESCRIPTION
Preserves the old PyClass instances and their memory and allocates the difference to the new size.
Also removes one copy, since it copies the data directly to the memory addresses of the old and new Python objects.