### PR TITLE
[FIX] Remove unallowed comment at end of directive

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1318,7 +1318,7 @@ class CodeGenerator(object):
         # signature which does not really specify the argument types. We have
         # to use a docstring for each method.
         code.add("""
-                   |#cython: c_string_encoding=ascii  # for cython>=0.19
+                   |#cython: c_string_encoding=ascii
                    |#cython: embedsignature=False
                    |from  libcpp.string  cimport string as libcpp_string
                    |from  libcpp.string  cimport string as libcpp_utf8_string


### PR DESCRIPTION
Yields `LookupError: unknown encoding: ascii  # for cython>=0.19` when adding e.g. c_string_type on the command line
The parser only splits at commas and reads everything after each "=".
https://github.com/cython/cython/blob/master/Cython/Compiler/Parsing.py#L3755
Not sure why this never came up. Either, it is only used if both c_string_encoding AND c_string_type are set, or the tests are just not enough to cover this.