### PR TITLE
improve error message for wrap-doc

### DIFF
--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -123,7 +123,7 @@ def parse_line_annotations(node, lines):
                     continue
                 if ":" in f:
                     key, value = f.split(":", 1)
-                    assert value.strip(), "empty value for key '%s'" % key
+                    assert value.strip(), "empty value (or excess space?) for key '%s' in line '%s'" % (key, line.rstrip())
                     result[key] = value
                 elif f.find("wrap-") != -1:
                     key, value = f, True


### PR DESCRIPTION
instead of `AssertionError: empty value for key 'wrap-doc'` 
you now get
`AssertionError: empty value (or excess space?) for key 'wrap-doc' in line '        void clearRanges() nogil except + # wrap-doc: resets all range dimensions as empty'`

if you accidentally added a space after `# wrap-doc: ...`.

side note: the parser will only store the first word of the documentation as `value`. Everything after was discarded in line 120 already.
Is this intended?