### PR TITLE
Fix handling of wrap-ignore for base classes to avoid invalid cimport…

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1951,7 +1951,15 @@ class CodeGenerator(object):
                     if resolved.__class__ in (ResolvedClass,):
                         # Skip classes that explicitely should not have a pxd
                         # import statement (abstract base classes and the like)
-                        if not resolved.no_pxd_import:
+                        ignore_base = False
+                        # Check if this class has a base class and that base class is wrap-ignored
+                        if resolved.cpp_decl.parent:
+                            base_class = resolved.cpp_decl.parent
+                            if base_class.annotations.get("wrap-ignore"):
+                                ignore_base = True
+                                print(f"[autowrap] Skipping pxd import for derived class '{resolved.name}' "
+                                f"because base '{base_class.name}' is wrap-ignored.")
+                        if not resolved.no_pxd_import and not ignore_base:
                             if resolved.cpp_decl.annotations.get("wrap-attach"):
                                 code.add("from $mname cimport __$name", locals())
                             else:


### PR DESCRIPTION
… in derived classes

Previously, autowrap would generate a `from ... cimport` statement for derived classes even if their base class was marked with `wrap-ignore`. This caused build failures due to missing .pxd files for ignored base classes, especially when those were the only contents of their file.

This change checks whether the base class has the `wrap-ignore` annotation and, if so, suppresses the cimport generation for the derived class. This prevents erroneous imports like:

  From ._pyopenms_20 cimport SpectrumAccessTransforming

When SpectrumAccessTransforming is intentionally not wrapped.

Also adds an optional debug message to clarify when this skip occurs.

This fix preserves expected behaviour for abstract base classes and improves compatibility when selectively wrapping a class hierarchy.

Fixes: #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of class imports by skipping pxd imports for classes whose base classes are marked to be ignored, preventing unnecessary or incorrect imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->