### PR TITLE
Use IntEnum instead of Enum for enum class wrappers

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -348,7 +348,7 @@ class CodeGenerator(object):
 
         pyi_code = "from __future__ import annotations\n"
         pyi_code += "from typing import overload, Any, List, Dict, Tuple, Set, Sequence, Union\n\n"
-        pyi_code += "from enum import Enum as _PyEnum\n\n"
+        pyi_code += "from enum import IntEnum as _PyEnum\n\n"
         pyi_code += "\n".join(ci.render() for ci in self.top_level_typestub_code)
         pyi_code += "\n\n"
         for n, c in self.typestub_codes.items():
@@ -2040,7 +2040,7 @@ class CodeGenerator(object):
                    |#Generated with autowrap %s and Cython (Parser) %s
                    |#cython: c_string_encoding=ascii
                    |#cython: embedsignature=False
-                   |from  enum            import Enum as _PyEnum
+                   |from  enum            import IntEnum as _PyEnum
                    |from  cpython         cimport Py_buffer
                    |from  cpython         cimport bool as pybool_t
                    |from  libcpp.string   cimport string as libcpp_string


### PR DESCRIPTION
## Summary
- Change generated Python enum wrappers to inherit from `IntEnum` instead of `Enum`
- Fixes a bug where set parameters containing enum class values fail with "TypeError: an integer is required"

## Problem
When using `cdef enum class` (C++ scoped enum) with set parameters, the generated Cython code would fail:

```cython
def setActivationMethods(self, set activation_methods):
    cdef int item0
    for item0 in activation_methods:  # FAILS: Enum objects can't be assigned to cdef int
        v0.insert(<_ActivationMethod> item0)
```

With plain `Enum`:
- `Enum` members are NOT integers
- `int(MyEnum.A)` throws `TypeError`
- Only `.value` works to get the integer

## Solution
Use `IntEnum` instead:
- `IntEnum` members ARE integers (`isinstance(val, int)` is True)
- Cython's `cdef int` can directly accept `IntEnum` values
- Round-trip operations (get → set) work correctly
- Backwards compatible with code expecting integers

## Testing
Tested with pyOpenMS which uses `cdef enum class ActivationMethod` in Precursor.pxd. The test that was previously failing (`testPrecursor`) now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated enum representation in generated type stubs and C imports. The base class used for enum type handling has been modified to improve type consistency and representation for scoped enums across generated code artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->