### PR TITLE
Add __len__ wrapping for C++ container classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ tests/test_files/namespaces.pyx
 tests/test_files/number_conv.pyx
 tests/test_files/enums.pyx
 tests/test_files/wrapped_container_wrapper.pyx
+tests/test_files/wrap_len_wrapper.pyx
 
 # generated typestubs
 tests/test_files/*.pyi

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -684,6 +684,18 @@ class CodeGenerator(object):
                 locals(),
             )
 
+        if len(r_class.wrap_len) != 0:
+            class_code.add(
+                """
+                            |
+                            |    def __len__(self):
+                            |      return deref(self.inst.get()).%s
+                            |
+                            """
+                % r_class.wrap_len[0],
+                locals(),
+            )
+
         if "wrap-buffer-protocol" in r_class.cpp_decl.annotations:
             buffer_parts = r_class.cpp_decl.annotations["wrap-buffer-protocol"][0].split(",")
             buffer_sourcer = buffer_parts[0]

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -176,6 +176,7 @@ class ResolvedClass(object):
     no_pxd_import: bool
     wrap_manual_memory: Union[bool, List[AnyStr]]
     wrap_hash: List[AnyStr]
+    wrap_len: List[AnyStr]
     local_map: Dict
     instance_map: Dict
     pxd_import_path: Optional[AnyStr]
@@ -206,6 +207,7 @@ class ResolvedClass(object):
         # elif empty list or list with actual content: pass
         assert isinstance(self.wrap_manual_memory, list)
         self.wrap_hash = decl.annotations.get("wrap-hash", [])
+        self.wrap_len = decl.annotations.get("wrap-len", [])
         self.local_map = local_map
         self.instance_map = instance_map
         self.pxd_import_path = None

--- a/tests/test_files/wrap_len_test.hpp
+++ b/tests/test_files/wrap_len_test.hpp
@@ -1,0 +1,138 @@
+#ifndef WRAP_LEN_TEST_HPP
+#define WRAP_LEN_TEST_HPP
+
+#include <vector>
+#include <string>
+#include <cstddef>
+
+// Basic container with size() - used with wrap-len
+class BasicContainer {
+private:
+    std::vector<int> data_;
+public:
+    BasicContainer() {}
+    BasicContainer(int count) {
+        for (int i = 0; i < count; ++i) {
+            data_.push_back(i);
+        }
+    }
+
+    size_t size() const { return data_.size(); }
+    void add(int value) { data_.push_back(value); }
+    void clear() { data_.clear(); }
+    int get(size_t index) const { return data_[index]; }
+};
+
+// Container with length() method instead of size()
+class LengthContainer {
+private:
+    std::vector<std::string> items_;
+public:
+    LengthContainer() {}
+
+    int length() const { return static_cast<int>(items_.size()); }
+    void append(const std::string& item) { items_.push_back(item); }
+    std::string getItem(int index) const { return items_[index]; }
+};
+
+// Container with count() method
+class CountContainer {
+private:
+    int count_;
+public:
+    CountContainer() : count_(0) {}
+    CountContainer(int initial) : count_(initial) {}
+
+    unsigned int count() const { return static_cast<unsigned int>(count_); }
+    void increment() { count_++; }
+    void decrement() { if (count_ > 0) count_--; }
+};
+
+// Container with size() but NO wrap-len annotation - should NOT have __len__
+class NoLenContainer {
+private:
+    std::vector<double> values_;
+public:
+    NoLenContainer() {}
+
+    size_t size() const { return values_.size(); }
+    void push(double v) { values_.push_back(v); }
+    double sum() const {
+        double s = 0;
+        for (auto v : values_) s += v;
+        return s;
+    }
+};
+
+// Container where size() is wrap-ignored
+// The size method should not be wrapped, but wrap-len should still work
+// since it calls the C++ method directly
+class IgnoredSizeContainer {
+private:
+    std::vector<int> data_;
+public:
+    IgnoredSizeContainer() {}
+    IgnoredSizeContainer(int count) {
+        for (int i = 0; i < count; ++i) {
+            data_.push_back(i * 10);
+        }
+    }
+
+    // This method is wrap-ignored but wrap-len should still work
+    size_t size() const { return data_.size(); }
+    void add(int v) { data_.push_back(v); }
+    int get(size_t i) const { return data_[i]; }
+};
+
+// Container with getSize() - different naming convention
+class GetSizeContainer {
+private:
+    int size_;
+public:
+    GetSizeContainer() : size_(0) {}
+    GetSizeContainer(int s) : size_(s) {}
+
+    size_t getSize() const { return static_cast<size_t>(size_); }
+    void setSize(int s) { size_ = s; }
+};
+
+// Empty container that always returns 0
+class EmptyContainer {
+public:
+    EmptyContainer() {}
+    size_t size() const { return 0; }
+};
+
+// Template container
+template <typename T>
+class TemplateContainer {
+private:
+    std::vector<T> data_;
+public:
+    TemplateContainer() {}
+
+    size_t size() const { return data_.size(); }
+    void add(const T& value) { data_.push_back(value); }
+    T get(size_t index) const { return data_[index]; }
+};
+
+// Container with both size() and length() - test that we can choose
+class DualLenContainer {
+private:
+    std::vector<int> data_;
+public:
+    DualLenContainer() {}
+    DualLenContainer(int count) {
+        for (int i = 0; i < count; ++i) {
+            data_.push_back(i);
+        }
+    }
+
+    // Returns actual size
+    size_t size() const { return data_.size(); }
+    // Returns size * 2 (for testing that wrap-len picks the right method)
+    size_t length() const { return data_.size() * 2; }
+    void add(int v) { data_.push_back(v); }
+};
+
+#endif // WRAP_LEN_TEST_HPP

--- a/tests/test_files/wrap_len_test.pxd
+++ b/tests/test_files/wrap_len_test.pxd
@@ -1,0 +1,110 @@
+# cython: language_level=3
+from libcpp.string cimport string as libcpp_string
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp cimport bool
+
+cdef extern from "wrap_len_test.hpp":
+
+    # Basic container with wrap-len using size()
+    cdef cppclass BasicContainer:
+        # wrap-len:
+        #   size()
+
+        BasicContainer()
+        BasicContainer(int count)
+
+        size_t size()
+        void add(int value)
+        void clear()
+        int get(size_t index)
+
+    # Container with length() method - wrap-len using length()
+    cdef cppclass LengthContainer:
+        # wrap-len:
+        #   length()
+
+        LengthContainer()
+
+        int length()
+        void append(libcpp_string item)
+        libcpp_string getItem(int index)
+
+    # Container with count() method
+    cdef cppclass CountContainer:
+        # wrap-len:
+        #   count()
+
+        CountContainer()
+        CountContainer(int initial)
+
+        unsigned int count()
+        void increment()
+        void decrement()
+
+    # Container with size() but NO wrap-len annotation
+    # This should NOT have __len__ in Python
+    cdef cppclass NoLenContainer:
+        NoLenContainer()
+
+        size_t size()
+        void push(double v)
+        double sum()
+
+    # Container where size() is wrap-ignored
+    # wrap-len should still work since it directly calls C++ method
+    cdef cppclass IgnoredSizeContainer:
+        # wrap-len:
+        #   size()
+
+        IgnoredSizeContainer()
+        IgnoredSizeContainer(int count)
+
+        size_t size()  # wrap-ignore
+        void add(int v)
+        int get(size_t i)
+
+    # Container using getSize() method name
+    cdef cppclass GetSizeContainer:
+        # wrap-len:
+        #   getSize()
+
+        GetSizeContainer()
+        GetSizeContainer(int s)
+
+        size_t getSize()
+        void setSize(int s)
+
+    # Empty container that always returns 0
+    cdef cppclass EmptyContainer:
+        # wrap-len:
+        #   size()
+
+        EmptyContainer()
+        size_t size()
+
+    # Template container - test wrap-len with templates
+    cdef cppclass TemplateContainer[T]:
+        # wrap-instances:
+        #   IntTemplateContainer := TemplateContainer[int]
+        #   StringTemplateContainer := TemplateContainer[libcpp_string]
+        # wrap-len:
+        #   size()
+
+        TemplateContainer()
+
+        size_t size()
+        void add(T value)
+        T get(size_t index)
+
+    # Container with both size() and length() - test that wrap-len picks correctly
+    # Here we choose length() which returns size * 2
+    cdef cppclass DualLenContainer:
+        # wrap-len:
+        #   length()
+
+        DualLenContainer()
+        DualLenContainer(int count)
+
+        size_t size()
+        size_t length()
+        void add(int v)

--- a/tests/test_wrap_len.py
+++ b/tests/test_wrap_len.py
@@ -1,0 +1,374 @@
+"""
+Tests for the wrap-len annotation feature.
+
+This test file verifies that autowrap correctly handles the wrap-len annotation
+which generates the Python __len__ special method for wrapped C++ classes.
+
+Test cases include:
+- Basic wrap-len with size() method
+- wrap-len with different method names (length(), count(), getSize())
+- Container without wrap-len annotation (should NOT have __len__)
+- wrap-len with wrap-ignored size() method (should still work)
+- wrap-len with template classes
+- wrap-len choosing between multiple potential methods
+- Edge cases: empty containers, zero length
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import pytest
+import os
+
+import autowrap.DeclResolver
+import autowrap.CodeGenerator
+import autowrap.PXDParser
+import autowrap.Utils
+import autowrap
+
+test_files = os.path.join(os.path.dirname(__file__), "test_files")
+
+
+@pytest.fixture(scope="module")
+def wrap_len_module():
+    """Compile and import the wrap_len_test module."""
+    target = os.path.join(test_files, "wrap_len_wrapper.pyx")
+
+    include_dirs = autowrap.parse_and_generate_code(
+        ["wrap_len_test.pxd"], root=test_files, target=target, debug=True
+    )
+
+    module = autowrap.Utils.compile_and_import(
+        "wrap_len_wrapper",
+        [target],
+        include_dirs,
+    )
+    return module
+
+
+class TestBasicWrapLen:
+    """Tests for basic wrap-len functionality with size() method."""
+
+    def test_len_returns_correct_value(self, wrap_len_module):
+        """Test that len() returns the correct size."""
+        m = wrap_len_module
+        container = m.BasicContainer(5)
+        assert len(container) == 5
+
+    def test_len_after_add(self, wrap_len_module):
+        """Test len() updates after adding elements."""
+        m = wrap_len_module
+        container = m.BasicContainer()
+        assert len(container) == 0
+
+        container.add(10)
+        assert len(container) == 1
+
+        container.add(20)
+        container.add(30)
+        assert len(container) == 3
+
+    def test_len_after_clear(self, wrap_len_module):
+        """Test len() returns 0 after clearing."""
+        m = wrap_len_module
+        container = m.BasicContainer(10)
+        assert len(container) == 10
+
+        container.clear()
+        assert len(container) == 0
+
+    def test_len_with_empty_container(self, wrap_len_module):
+        """Test len() with empty container."""
+        m = wrap_len_module
+        container = m.BasicContainer()
+        assert len(container) == 0
+
+    def test_len_in_boolean_context(self, wrap_len_module):
+        """Test container in boolean context (relies on __len__)."""
+        m = wrap_len_module
+
+        empty = m.BasicContainer()
+        non_empty = m.BasicContainer(3)
+
+        # In Python, objects with __len__ returning 0 are falsy
+        assert not empty  # Should be falsy (len == 0)
+        assert non_empty  # Should be truthy (len > 0)
+
+
+class TestLengthMethod:
+    """Tests for wrap-len with length() method instead of size()."""
+
+    def test_length_method(self, wrap_len_module):
+        """Test wrap-len using length() method."""
+        m = wrap_len_module
+        container = m.LengthContainer()
+        assert len(container) == 0
+
+        container.append(b"hello")
+        assert len(container) == 1
+
+        container.append(b"world")
+        assert len(container) == 2
+
+    def test_length_int_return_type(self, wrap_len_module):
+        """Test that int return type works correctly."""
+        m = wrap_len_module
+        container = m.LengthContainer()
+
+        # Add multiple items
+        for i in range(100):
+            container.append(b"item")
+
+        assert len(container) == 100
+
+
+class TestCountMethod:
+    """Tests for wrap-len with count() method."""
+
+    def test_count_method(self, wrap_len_module):
+        """Test wrap-len using count() method."""
+        m = wrap_len_module
+        container = m.CountContainer(5)
+        assert len(container) == 5
+
+    def test_count_increment_decrement(self, wrap_len_module):
+        """Test len() after increment/decrement operations."""
+        m = wrap_len_module
+        container = m.CountContainer(10)
+        assert len(container) == 10
+
+        container.increment()
+        assert len(container) == 11
+
+        container.decrement()
+        container.decrement()
+        assert len(container) == 9
+
+    def test_count_unsigned_int_return(self, wrap_len_module):
+        """Test that unsigned int return type works correctly."""
+        m = wrap_len_module
+        container = m.CountContainer(0)
+        assert len(container) == 0
+
+        # Can't decrement below 0 (unsigned)
+        container.decrement()
+        assert len(container) == 0
+
+
+class TestNoWrapLenAnnotation:
+    """Tests for containers WITHOUT wrap-len annotation."""
+
+    def test_no_len_method(self, wrap_len_module):
+        """Test that container without wrap-len has no __len__."""
+        m = wrap_len_module
+        container = m.NoLenContainer()
+
+        # Should NOT have __len__ method
+        assert not hasattr(container, '__len__')
+
+        # len() should raise TypeError
+        with pytest.raises(TypeError):
+            len(container)
+
+    def test_size_method_still_accessible(self, wrap_len_module):
+        """Test that size() method is still callable without __len__."""
+        m = wrap_len_module
+        container = m.NoLenContainer()
+        container.push(1.0)
+        container.push(2.0)
+
+        # size() method should work
+        assert container.size() == 2
+
+
+class TestIgnoredSizeMethod:
+    """Tests for wrap-len when size() method is wrap-ignored."""
+
+    def test_len_works_with_ignored_size(self, wrap_len_module):
+        """Test that __len__ works even when size() is wrap-ignored."""
+        m = wrap_len_module
+        container = m.IgnoredSizeContainer(5)
+
+        # __len__ should work (calls C++ directly)
+        assert len(container) == 5
+
+    def test_size_method_not_exposed(self, wrap_len_module):
+        """Test that size() method is NOT exposed in Python."""
+        m = wrap_len_module
+        container = m.IgnoredSizeContainer(5)
+
+        # size() should NOT be accessible (wrap-ignore)
+        assert not hasattr(container, 'size')
+
+    def test_len_updates_correctly(self, wrap_len_module):
+        """Test that len() updates correctly with ignored size()."""
+        m = wrap_len_module
+        container = m.IgnoredSizeContainer()
+        assert len(container) == 0
+
+        container.add(100)
+        container.add(200)
+        assert len(container) == 2
+
+
+class TestGetSizeMethod:
+    """Tests for wrap-len with getSize() method naming convention."""
+
+    def test_get_size_method(self, wrap_len_module):
+        """Test wrap-len using getSize() method."""
+        m = wrap_len_module
+        container = m.GetSizeContainer(42)
+        assert len(container) == 42
+
+    def test_get_size_set_size(self, wrap_len_module):
+        """Test len() after setSize()."""
+        m = wrap_len_module
+        container = m.GetSizeContainer()
+        assert len(container) == 0
+
+        container.setSize(100)
+        assert len(container) == 100
+
+        container.setSize(0)
+        assert len(container) == 0
+
+
+class TestEmptyContainer:
+    """Tests for container that always returns 0."""
+
+    def test_always_empty(self, wrap_len_module):
+        """Test container that always returns 0 for size."""
+        m = wrap_len_module
+        container = m.EmptyContainer()
+        assert len(container) == 0
+
+    def test_empty_is_falsy(self, wrap_len_module):
+        """Test that empty container is falsy in boolean context."""
+        m = wrap_len_module
+        container = m.EmptyContainer()
+        assert not container  # Should be falsy
+
+
+class TestTemplateContainer:
+    """Tests for wrap-len with template classes."""
+
+    def test_int_template_container(self, wrap_len_module):
+        """Test wrap-len with int template instantiation."""
+        m = wrap_len_module
+        container = m.IntTemplateContainer()
+        assert len(container) == 0
+
+        container.add(1)
+        container.add(2)
+        container.add(3)
+        assert len(container) == 3
+
+    def test_string_template_container(self, wrap_len_module):
+        """Test wrap-len with string template instantiation."""
+        m = wrap_len_module
+        container = m.StringTemplateContainer()
+        assert len(container) == 0
+
+        container.add(b"hello")
+        container.add(b"world")
+        assert len(container) == 2
+
+
+class TestDualLenContainer:
+    """Tests for container with both size() and length() methods."""
+
+    def test_wrap_len_chooses_correct_method(self, wrap_len_module):
+        """Test that wrap-len uses the specified method (length())."""
+        m = wrap_len_module
+        container = m.DualLenContainer(5)
+
+        # wrap-len is configured to use length() which returns size * 2
+        assert len(container) == 10  # 5 * 2
+
+        # The size() method should still return actual size
+        assert container.size() == 5
+
+    def test_dual_len_after_add(self, wrap_len_module):
+        """Test dual len container after adding elements."""
+        m = wrap_len_module
+        container = m.DualLenContainer()
+
+        assert len(container) == 0
+        assert container.size() == 0
+
+        container.add(1)
+        assert len(container) == 2  # length() = size * 2
+        assert container.size() == 1
+
+        container.add(2)
+        container.add(3)
+        assert len(container) == 6  # length() = 3 * 2
+        assert container.size() == 3
+
+
+class TestLenWithIterableProtocol:
+    """Tests for __len__ interaction with other container protocols."""
+
+    def test_len_consistent_with_iteration(self, wrap_len_module):
+        """Test that len() is consistent with number of elements."""
+        m = wrap_len_module
+        container = m.BasicContainer(10)
+
+        # len() should match number of gettable elements
+        assert len(container) == 10
+        for i in range(len(container)):
+            # Should be able to get all elements without error
+            val = container.get(i)
+            assert val == i
+
+    def test_len_in_list_comprehension_context(self, wrap_len_module):
+        """Test using len() in list comprehension."""
+        m = wrap_len_module
+        container = m.BasicContainer(5)
+
+        # Using len() to iterate
+        values = [container.get(i) for i in range(len(container))]
+        assert values == [0, 1, 2, 3, 4]
+
+
+class TestLenEdgeCases:
+    """Edge cases and corner cases for __len__."""
+
+    def test_large_size(self, wrap_len_module):
+        """Test with large container size."""
+        m = wrap_len_module
+        container = m.BasicContainer(10000)
+        assert len(container) == 10000
+
+    def test_len_type_is_int(self, wrap_len_module):
+        """Test that len() returns an int."""
+        m = wrap_len_module
+        container = m.BasicContainer(5)
+        result = len(container)
+        assert isinstance(result, int)
+
+    def test_multiple_len_calls(self, wrap_len_module):
+        """Test that multiple len() calls return consistent results."""
+        m = wrap_len_module
+        container = m.BasicContainer(42)
+
+        # Multiple calls should return same value
+        for _ in range(100):
+            assert len(container) == 42
+
+    def test_len_on_multiple_instances(self, wrap_len_module):
+        """Test len() on multiple container instances."""
+        m = wrap_len_module
+
+        c1 = m.BasicContainer(5)
+        c2 = m.BasicContainer(10)
+        c3 = m.BasicContainer(15)
+
+        assert len(c1) == 5
+        assert len(c2) == 10
+        assert len(c3) == 15
+
+        # Modifying one shouldn't affect others
+        c1.add(100)
+        assert len(c1) == 6
+        assert len(c2) == 10
+        assert len(c3) == 15


### PR DESCRIPTION
Implement the wrap-len annotation which allows C++ classes with container interfaces to expose Python's __len__ special method. This enables len() calls on wrapped objects.

Changes:
- Add wrap_len attribute to ResolvedClass in DeclResolver.py
- Add __len__ code generation in CodeGenerator.py
- Add comprehensive tests covering:
  - Basic wrap-len with size() method
  - Different method names (length(), count(), getSize())
  - Container without wrap-len (no __len__ generated)
  - wrap-len with wrap-ignored size() method (still works)
  - Template classes with wrap-len
  - Choosing between multiple methods (size vs length)
  - Boolean context (empty containers are falsy)
  - Edge cases (empty, large containers)

Usage in pxd files:
    cdef cppclass Container: # wrap-len:
        #   size()
        size_t size()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wrapped classes now support the wrap-len annotation, enabling automatic `__len__()` method generation for Python compatibility. Supports multiple length-reporting method names (size(), length(), count(), getSize()).

* **Tests**
  * Comprehensive test coverage added for wrap-len functionality, including template containers, wrap-ignore interactions, and Python iteration compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->