### PR TITLE
Add test for enum-based overload resolution

### DIFF
--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -110,6 +110,18 @@ def test_enums():
     with pytest.raises(AssertionError):
         foo.enumToInt(myenum2_a)
 
+    # Test 5: Overload resolution works correctly for different enum types
+    # The process() method is overloaded: process(MyEnum) and process(MyEnum2)
+    # Python should dispatch to the correct overload based on enum type
+    assert foo.process(mod.Foo.MyEnum.A) == b"MyEnum"
+    assert foo.process(mod.Foo.MyEnum.B) == b"MyEnum"
+    assert foo.process(mod.Foo.MyEnum2.A) == b"MyEnum2"
+    assert foo.process(mod.Foo.MyEnum2.C) == b"MyEnum2"
+
+    # Test 6: Overloaded method rejects wrong enum type from different namespace
+    with pytest.raises(Exception):
+        foo.process(mod.Foo2.MyEnum.A)
+
 
 def test_number_conv():
     target = os.path.join(test_files, "generated", "number_conv.pyx")

--- a/tests/test_files/enums.hpp
+++ b/tests/test_files/enums.hpp
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+#include <string>
+
 // Class with nested scoped enums
 class Foo
 {
@@ -43,6 +45,11 @@ public:
        }
        return 0; // unreachable, but silences compiler warning
     };
+
+    // Overloaded methods accepting different enum types - tests overload resolution
+    // Python should correctly dispatch based on the enum type passed
+    std::string process(MyEnum e) { return "MyEnum"; }
+    std::string process(MyEnum2 e) { return "MyEnum2"; }
 };
 
 // Separate namespace with an enum of the same name as Foo::MyEnum

--- a/tests/test_files/enums.pxd
+++ b/tests/test_files/enums.pxd
@@ -1,4 +1,5 @@
 # cython: language_level=3
+from libcpp.string cimport string as libcpp_string
 #
 # =============================================================================
 # Example: Wrapping C++ Enums in Different Namespaces
@@ -44,6 +45,9 @@ cdef extern from "enums.hpp":
      cdef cppclass Foo:
         # Method accepts Foo_MyEnum (which maps to Foo::MyEnum in C++)
         int enumToInt(Foo_MyEnum e)
+        # Overloaded methods for testing enum-based overload resolution
+        libcpp_string process(Foo_MyEnum e)
+        libcpp_string process(Foo_MyEnum2 e)
 
 cdef extern from "enums.hpp":
      cdef cppclass Foo2:


### PR DESCRIPTION
## Summary

- Adds test coverage to verify that overloaded methods with different enum parameter types dispatch correctly
- Confirms that scoped enum handling already supports overload resolution via `isinstance()` type checks
- Addresses issue #233 by documenting that the core functionality is already implemented

## Changes

- Add overloaded `process(MyEnum)` and `process(MyEnum2)` methods to `enums.hpp`
- Declare process methods in `enums.pxd`  
- Add tests verifying:
  - Correct dispatch based on enum type
  - Rejection of wrong enum types from different namespaces

## Test plan

- [x] `pytest tests/test_code_generator.py::test_enums -v` passes
- [x] `pytest tests/test_code_generator.py::test_enum_class_forward_declaration -v` passes

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for enum overload resolution, validating correct dispatch for different enum types and type safety across namespaces.

* **New Features**
  * Enhanced enum processing with overload-based dispatch capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->